### PR TITLE
chore: add protocol to cozy client js init

### DIFF
--- a/packages/cozy-scripts/template/app/src/targets/browser/index.jsx
+++ b/packages/cozy-scripts/template/app/src/targets/browser/index.jsx
@@ -58,8 +58,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   appLocale = getDataOrDefault(data.cozyLocale, 'en')
 
+  const protocol = window.location ? window.location.protocol : 'https:'
+
   cozy.client.init({
-    cozyURL: '//' + data.cozyDomain,
+    cozyURL: `${protocol}//${data.cozyDomain}`,
     token: data.cozyToken
   })
   cozy.bar.init({


### PR DESCRIPTION
If you want to use pouch, you need to specify a protocol for the URL.