### PR TITLE
feat: dont bail when watching

### DIFF
--- a/packages/cozy-scripts/scripts/watch.js
+++ b/packages/cozy-scripts/scripts/watch.js
@@ -4,9 +4,7 @@ const webpack = require('webpack')
 const appConfig = require('./config.js')
 const colorize = require('../utils/_colorize.js')
 
-const compiler = webpack(Object.assign({}, appConfig, {
-  bail: true
-}))
+const compiler = webpack(Object.assign({}, appConfig))
 
 const isDebugMode = process.env.COZY_SCRIPTS_DEBUG === 'true'
 


### PR DESCRIPTION
cf https://github.com/CPatchane/create-cozy-app/issues/130

>bail
>Fail out on the first error instead of tolerating it.

Source : https://webpack.js.org/configuration/other-options/#bail

Using `bail: true` closes the watch process if there is an error. I would expect a watcher to continue watching if there is a problem otherwise it is very inconvenient if you are trying to remove several errors and have to restart the watcher every time.