### PR TITLE
Downgrade chalk to v2.2.2 due to undefined issue

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.progress.js
+++ b/packages/cozy-scripts/config/webpack.config.progress.js
@@ -2,13 +2,7 @@
 
 const Progress = require('progress')
 const webpack = require('webpack')
-
-// FIXME For some weird reasons, hex is not available from chalk in the jest
-// tests environment, so we have to explicitly use colors ansi characters
-// const colorize = require('../utils/_colorize')
-// const percent = colorize.blue(':percent')
-// const completeElement = colorize.bgBlue(' ')
-// const incompleteElement = colorize.bgWhite(' ')
+const colorize = require('../utils/_colorize')
 
 function CustomProgressPlugin () {
   if (!process.stderr.isTTY) {
@@ -19,13 +13,13 @@ function CustomProgressPlugin () {
     // message template
     [
       ':bar',
-      '\u001b[38;2;41;126;242m:percent\u001b[39m',
+      colorize.blue(':percent'),
       ':msg'
     ].join(' '),
     // progress bar options
     {
-      complete: '\u001b[48;2;41;126;242m \u001b[49m',
-      incomplete: '\u001b[47m \u001b[49m',
+      complete: colorize.bgBlue(' '),
+      incomplete: colorize.bgWhite(' '),
       width: 2000, // exceed length is handled
       total: 100,
       clear: false

--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -18,7 +18,7 @@
     "babel-core": "6.26.0",
     "babel-eslint": "8.2.1",
     "babel-loader": "7.1.2",
-    "chalk": "2.3.0",
+    "chalk": "2.2.2",
     "commander": "2.13.0",
     "copy-webpack-plugin": "4.3.1",
     "cross-spawn": "5.1.0",

--- a/packages/cozy-scripts/scripts/watch.js
+++ b/packages/cozy-scripts/scripts/watch.js
@@ -2,6 +2,7 @@
 
 const webpack = require('webpack')
 const configs = require('./config')
+const colorize = require('../utils/_colorize')
 
 // the main app config is at the first position
 const appConfig = configs[0]
@@ -16,9 +17,7 @@ module.exports = (successCallback) => {
   let watcher
   watcher = compiler.watch({}, (err, stats) => {
     if (err) {
-      // FIXME For some weird reasons, hex is not available from chalk in the jest
-      // tests environment, so we have to explicitly use colors ansi characters
-      console.error(new Error(`\u001b[38;2;221;5;5m${err}\u001b[39m`))
+      console.error(new Error(colorize.red(err)))
     }
 
     console.log(stats.toString({

--- a/packages/cozy-scripts/yarn.lock
+++ b/packages/cozy-scripts/yarn.lock
@@ -817,9 +817,9 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@2.3.0, chalk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+chalk@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.2.2.tgz#4403f5cf18f35c05f51fbdf152bf588f956cf7cb"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -838,6 +838,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
 chalk@^2.0.0, chalk@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.2.0.tgz#477b3bf2f9b8fd5ca9e429747e37f724ee7af240"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+chalk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"


### PR DESCRIPTION
Issue:

```
myapptest/node_modules/cozy-scripts/node_modules/chalk/index.js:82
				const open = ansiStyles.color[levelMapping[level]][model].apply(null, arguments);
				                                                  ^

TypeError: Cannot read property 'hex' of undefined
    at Function.<anonymous> (myapptest/node_modules/cozy-scripts/node_modules/chalk/index.js:82:55)
    at Object.<anonymous> (myapptest/node_modules/cozy-scripts/utils/_colorize.js:7:15)
    at Module._compile (module.js:643:30)
    at Object.Module._extensions..js (module.js:654:10)
    at Module.load (module.js:556:32)
    at tryModuleLoad (module.js:499:12)
    at Function.Module._load (module.js:491:3)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
```

See https://github.com/chalk/chalk/issues/248