### PR TITLE
fix: don't ignore en locale

### DIFF
--- a/packages/cozy-scripts/.gitignore
+++ b/packages/cozy-scripts/.gitignore
@@ -12,8 +12,8 @@ coverage/
 
 
 # Locales
-**/locales/*
-!**/locales/en.json
+src/locales/*
+!src/locales/en.json
 
 
 # transifex


### PR DESCRIPTION
You may want to double check this PR, but when I created my app, `src/locales/en.json` was git-ignored, and the `locales` folder wasn't added at all. I don't understand why, but the `**` pattern seems to make the negating line fail.