### PR TITLE
Disable webpack symlinks resolving

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -12,7 +12,9 @@ module.exports = {
   },
   resolve: {
     modules: [paths.appNodeModules, paths.appSrc],
-    extensions: ['.js', '.json', '.css']
+    extensions: ['.js', '.json', '.css'],
+    // linked package will still be see as a node_modules package
+    symlinks: false
   },
   bail: true,
   module: {

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -283,6 +283,7 @@ Array [
         ".tmp_test/test-app-vue/node_modules",
         ".tmp_test/test-app-vue/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -571,6 +572,7 @@ Array [
         ".tmp_test/test-app-vue/node_modules",
         ".tmp_test/test-app-vue/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -859,6 +861,7 @@ Array [
         ".tmp_test/test-app-vue/node_modules",
         ".tmp_test/test-app-vue/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -1136,6 +1139,7 @@ Array [
         ".tmp_test/test-app-vue/node_modules",
         ".tmp_test/test-app-vue/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -1432,6 +1436,7 @@ Array [
         ".tmp_test/test-app-vue/node_modules",
         ".tmp_test/test-app-vue/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -1714,6 +1719,7 @@ Array [
         ".tmp_test/test-app-vue/node_modules",
         ".tmp_test/test-app-vue/src",
       ],
+      "symlinks": false,
     },
   },
 ]

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -407,6 +407,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -738,6 +739,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -1069,6 +1071,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -1389,6 +1392,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -1728,6 +1732,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -2053,6 +2058,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
   },
 ]
@@ -2430,6 +2436,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
   },
   Object {
@@ -2630,6 +2637,7 @@ Array [
         ".tmp_test/test-app/node_modules",
         ".tmp_test/test-app/src",
       ],
+      "symlinks": false,
     },
     "target": "node",
   },


### PR DESCRIPTION
By default it's enabled by webpack and symlinked resources are resolved to their real path, not their symlinked location.