### PR TITLE
Build services in `build/services/` folder instead of `build/`

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.services.js
+++ b/packages/cozy-scripts/config/webpack.config.services.js
@@ -28,6 +28,10 @@ const config = {
     }
   },
   entry: servicesEntries,
+  output: {
+    path: paths.appServicesBuild,
+    filename: '[name].js'
+  },
   target: 'node',
   devtool: false,
   plugins: [

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -2604,7 +2604,7 @@ Array [
     "multiple": Object {},
     "output": Object {
       "filename": "[name].js",
-      "path": ".tmp_test/test-app/build",
+      "path": ".tmp_test/test-app/build/services",
     },
     "plugins": Array [
       Object {

--- a/packages/cozy-scripts/utils/paths.js
+++ b/packages/cozy-scripts/utils/paths.js
@@ -18,6 +18,7 @@ const resolveWithExtension = (path, extension) => {
 module.exports = {
   appPath: resolveApp('.'),
   appBuild: resolveApp('build'),
+  appServicesBuild: resolveApp('build/services'),
   appBuildAssetsJson: resolveApp('build/assets/json'),
   appPackageJson: resolveApp('package.json'),
   appManifest: resolveApp('manifest.webapp'),


### PR DESCRIPTION
Was previously built directly in `build/` folder.