### PR TITLE
feat: add root in image path in webpack config ✨

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.pictures.js
+++ b/packages/cozy-scripts/config/webpack.config.pictures.js
@@ -18,7 +18,7 @@ module.exports = {
         exclude: /(sprites|icons)/,
         loader: `file-loader`,
         options: {
-          outputPath: 'img/',
+          outputPath: '/img/',
           name: `[name]${environment === 'production' ? '.[hash]' : ''}.[ext]`
         }
       }

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -120,7 +120,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -409,7 +409,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -698,7 +698,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -986,7 +986,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -1265,7 +1265,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -1558,7 +1558,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -239,7 +239,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -571,7 +571,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -903,7 +903,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -1234,7 +1234,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -1556,7 +1556,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -1892,7 +1892,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -2269,7 +2269,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },
@@ -2596,7 +2596,7 @@ Array [
           "loader": "file-loader",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
+            "outputPath": "/img/",
           },
           "test": Object {},
         },


### PR DESCRIPTION
The goal of this PR is to made images work when we are not at website root.

For example in `http://collect-greg.mycozy.cloud/intents/`.