### PR TITLE
feat: turn off rules that are not compatible with prettier.

### DIFF
--- a/packages/eslint-config-cozy-app/index.js
+++ b/packages/eslint-config-cozy-app/index.js
@@ -2,7 +2,7 @@
 
 // standardJS
 module.exports = {
-  extends: ['standard', 'standard-jsx'],
+  extends: ['standard', 'standard-jsx', 'eslint-config-prettier'],
   parser: 'babel-eslint',
   parserOptions: { ecmaFeatures: { jsx: true } },
   env: {

--- a/packages/eslint-config-cozy-app/package.json
+++ b/packages/eslint-config-cozy-app/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "babel-eslint": "^8.0.1",
     "eslint": "^4.9.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-config-standard": "^11.0.0",
     "eslint-config-standard-jsx": "^5.0.0",
     "eslint-plugin-import": "^2.7.0",

--- a/packages/eslint-config-cozy-app/yarn.lock
+++ b/packages/eslint-config-cozy-app/yarn.lock
@@ -347,6 +347,12 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-config-standard-jsx@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz#4abfac554f38668e0078c664569e7b2384e5d2aa"
@@ -569,6 +575,10 @@ function-bind@^1.0.2, function-bind@^1.1.1:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"


### PR DESCRIPTION
This way we can run prettier then eslint.

https://stackoverflow.com/questions/44690308/whats-the-difference-between-prettier-eslint-eslint-plugin-prettier-and-eslint