### PR TITLE
Remove email CLI question + use default travis email to deploy

### DIFF
--- a/packages/cozy-scripts/scripts/init.js
+++ b/packages/cozy-scripts/scripts/init.js
@@ -15,7 +15,6 @@ module.exports = function (appPath, appName, cliOptions, gracefulRootExit, overr
     <APP_SLUG> slug of the app, must be unique for the apps registry
     <APP_NAME> application full name
     <USERNAME_GH> : github author (that will host the project) username
-    <USER_EMAIL_GH> : github author (that will host the project) email
   */
   const promptProperties = [
     {
@@ -51,13 +50,6 @@ module.exports = function (appPath, appName, cliOptions, gracefulRootExit, overr
       name: '<USERNAME_GH>',
       description: colorize.orange('Your github username?'),
       pattern: /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i,
-      message: 'Must be valid github username',
-      required: true
-    },
-    {
-      name: '<USER_EMAIL_GH>',
-      description: colorize.orange('Your github email (for the application build deployment script)?'),
-      pattern: /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
       message: 'Must be valid github username',
       required: true
     }

--- a/packages/cozy-scripts/template-vue/package.json
+++ b/packages/cozy-scripts/template-vue/package.json
@@ -26,7 +26,7 @@
     "config:mobile:production": "NODE_ENV=mobile:production cozy-scripts --show-config",
     "config:mobile:development": "NODE_ENV=mobile:development cozy-scripts --show-config",
     "deploy": "git-directory-deploy --directory build/ --branch build --repo=https://github.com/<USERNAME_GH>/<SLUG_GH>.git",
-    "deploy:travis": "git-directory-deploy --username <USERNAME_GH> --email <USER_EMAIL_GH> --directory build/ --repo=https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git",
+    "deploy:travis": "git-directory-deploy --username <USERNAME_GH> --email deploy@travis-ci.org --directory build/ --repo=https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git",
     "test": "npm-run-all --serial lint test:jest",
     "test:jest": "jest --verbose --coverage",
     "stack:docker": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev",

--- a/packages/cozy-scripts/template/package.json
+++ b/packages/cozy-scripts/template/package.json
@@ -26,7 +26,7 @@
     "config:mobile:production": "NODE_ENV=mobile:production cozy-scripts --show-config",
     "config:mobile:development": "NODE_ENV=mobile:development cozy-scripts --show-config",
     "deploy": "git-directory-deploy --directory build/ --branch build --repo=https://github.com/<USERNAME_GH>/<SLUG_GH>.git",
-    "deploy:travis": "git-directory-deploy --username <USERNAME_GH> --email <USER_EMAIL_GH> --directory build/ --repo=https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git",
+    "deploy:travis": "git-directory-deploy --username <USERNAME_GH> --email deploy@travis-ci.org --directory build/ --repo=https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git",
     "test": "npm-run-all --serial lint test:jest",
     "test:jest": "jest --verbose --coverage",
     "stack:docker": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev",

--- a/packages/cozy-scripts/test/scripts-vue.spec.js
+++ b/packages/cozy-scripts/test/scripts-vue.spec.js
@@ -58,8 +58,7 @@ const overrideData = {
   '<SLUG_GH>': appName,
   '<APP_SLUG>': appName,
   '<APP_NAME>': appName,
-  '<USERNAME_GH>': 'foo',
-  '<USER_EMAIL_GH>': 'mock@example.test'
+  '<USERNAME_GH>': 'foo'
 }
 
 function getConfig () {

--- a/packages/cozy-scripts/test/scripts.spec.js
+++ b/packages/cozy-scripts/test/scripts.spec.js
@@ -62,8 +62,7 @@ const overrideData = {
   '<SLUG_GH>': appName,
   '<APP_SLUG>': appName,
   '<APP_NAME>': appName,
-  '<USERNAME_GH>': 'foo',
-  '<USER_EMAIL_GH>': 'mock@example.test'
+  '<USERNAME_GH>': 'foo'
 }
 
 function getConfig () {


### PR DESCRIPTION
We used to ask for the user email for the Travis deployment script.
Now we use deploy@travis-ci.org by default for this script.
So we can remove this email CLI question.