### PR TITLE
chore: better clean tasks 📝

### DIFF
--- a/packages/cozy-scripts/template-vue/package.json
+++ b/packages/cozy-scripts/template-vue/package.json
@@ -2,8 +2,8 @@
   "name": "cozy-scripts-template-vue",
   "version": "0.1.0",
   "scripts": {
-    "clean:browser": "rm -rf build/*",
-    "clean:mobile": "rm -rf mobile/www/*",
+    "clean:browser": "find ./build -name '*' ! -name 'build' -print0 | xargs -0 -n 10 rm -rf",
+    "clean:mobile": "find ./mobile/www -name '*' ! -path './mobile/www' -print0 | xargs -0 -n 10 rm -rf",
     "tx": "tx pull --all || true",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint '{src,test}/**/*.{js}'",

--- a/packages/cozy-scripts/template/package.json
+++ b/packages/cozy-scripts/template/package.json
@@ -2,8 +2,8 @@
   "name": "cozy-scripts-template",
   "version": "0.1.0",
   "scripts": {
-    "clean:browser": "rm -rf build/*",
-    "clean:mobile": "rm -rf mobile/www/*",
+    "clean:browser": "find ./build -name '*' ! -name 'build' -print0 | xargs -0 -n 10 rm -rf",
+    "clean:mobile": "find ./mobile/www -name '*' ! -path './mobile/www' -print0 | xargs -0 -n 10 rm -rf",
     "tx": "tx pull --all || true",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint '{src,test}/**/*.{js,jsx}'",


### PR DESCRIPTION
The goal of this PR is to avoid having the error message `sh: /bin/rm: Argument list too long` when running `rm *` on a huge `build` directory.

The main idea is to use a find command, [as shown here](https://wiki.debian.org/CommonErrorMessages/ArgumentListTooLo).

Also, we can filter on root folder by using `! -name 'build'`, [like explained here](https://superuser.com/questions/397307/how-to-ignore-certain-filenames-using-find/397325#397325)