### PR TITLE
Add renovate.json config files to templates

### DIFF
--- a/packages/cozy-scripts/template-vue/app/renovate.json
+++ b/packages/cozy-scripts/template-vue/app/renovate.json
@@ -1,0 +1,19 @@
+{
+  "assignees": [],
+  "labels": [],
+  "automerge": false,
+  "extends": [
+    "config:js-lib"
+  ],
+  "packageFiles": [
+    {
+      "packageFile": "package.json",
+      "devDependencies": {
+        "pinVersions": true
+      },
+      "dependencies": {
+        "pinVersions": true
+      }
+    }
+  ]
+}

--- a/packages/cozy-scripts/template/app/renovate.json
+++ b/packages/cozy-scripts/template/app/renovate.json
@@ -1,0 +1,19 @@
+{
+  "assignees": [],
+  "labels": [],
+  "automerge": false,
+  "extends": [
+    "config:js-lib"
+  ],
+  "packageFiles": [
+    {
+      "packageFile": "package.json",
+      "devDependencies": {
+        "pinVersions": true
+      },
+      "dependencies": {
+        "pinVersions": true
+      }
+    }
+  ]
+}

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -1751,6 +1751,7 @@ Array [
   "manifest.webapp",
   "node_modules",
   "package.json",
+  "renovate.json",
   "src/assets/icons/icon-bullet-point.svg",
   "src/components/App.vue",
   "src/components/HelloViews/Hello1.vue",

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -2090,6 +2090,7 @@ Array [
   "manifest.webapp",
   "node_modules",
   "package.json",
+  "renovate.json",
   "src/assets/icons/icon-bullet-point.svg",
   "src/components/App.jsx",
   "src/components/HelloViews/Hello1.jsx",


### PR DESCRIPTION
We recommend this configuration of the [renovate app](https://renovateapp.com) to maintain all the application dependencies up to date by opening pull requests automatically (`yarn` and lockfile handled).