### PR TITLE
fix: Ensure watch rethrows error

### DIFF
--- a/packages/cozy-scripts/scripts/watch.js
+++ b/packages/cozy-scripts/scripts/watch.js
@@ -24,7 +24,7 @@ module.exports = (buildOptions, successCallback) => {
   let watcher
   watcher = compiler.watch({}, (err, stats) => {
     if (err) {
-      console.error(new Error(colorize.red(err)))
+      throw new Error(colorize.red(err))
     }
 
     console.log(stats.toString({


### PR DESCRIPTION
Otherwise one will see another confusing error following the initial one in
the output:

    TypeError: Cannot read property 'toString' of undefined