### PR TITLE
Use now node 8+ (drop v6 and v7 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 matrix:
   fast_finish: true
 node_js:
-- 6
+- 8
 env:
   matrix:
   - TESTS_SUITE=cli

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ By default, `create-cozy-app` will use the [`cozy-scripts`](https://github.com/C
 
 #### Requirements
 
- - Node.js version 6 or higher;
+ - Node.js version 8 or higher;
  - [Yarn](https://yarnpkg.com). Yarn is a Node.js package manager, like `npm`;
  - a running [Cozy development environment](https://docs.cozy.io/en/dev/app/#install-the-development-environment) (optional if you just want to use standalone mode);
 

--- a/packages/create-cozy-app/README.md
+++ b/packages/create-cozy-app/README.md
@@ -34,7 +34,7 @@ By default, `create-cozy-app` will use the [`cozy-scripts`](https://github.com/C
 
 #### Requirements
 
- - Node.js version 6 or higher;
+ - Node.js version 8 or higher;
  - [Yarn](https://yarnpkg.com). Yarn is a Node.js package manager, like `npm`;
  - a running [Cozy development environment](https://docs.cozy.io/en/dev/app/#install-the-development-environment) (optional if you just want to use standalone mode);
 

--- a/packages/create-cozy-app/index.js
+++ b/packages/create-cozy-app/index.js
@@ -9,10 +9,10 @@ var semver = currentNodeVersion.split('.')
 var major = semver[0]
 const execSync = require('child_process').execSync
 
-if (major < 6) {
+if (major < 8) {
   console.error(
     chalk.red(`You are running Node v${currentNodeVersion}.
-      create-cozy-app requires Node v6 minimum, please update you version of Node`
+      create-cozy-app requires Node v8 minimum, please use a more recent version of Node`
     )
   )
   process.exit(1)


### PR DESCRIPTION
The new `fs-extra` (v6) now supports only node 8+