### PR TITLE
Split configurations in eslint-config-cozy-app

### DIFF
--- a/packages/eslint-config-cozy-app/README.md
+++ b/packages/eslint-config-cozy-app/README.md
@@ -20,9 +20,9 @@
 
 ### What's eslint-config-cozy-app?
 
-A shareable configuration for Cozy Application using Standard configs and `babel-eslint` parser with JSX support.
+Shareable configurations for Cozy Applications and scripts.
 
-This package is an ESLint shareable config used by [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app).
+> This package is an ESLint shareable config already used by [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app).
 
 To install:
 
@@ -32,17 +32,48 @@ yarn add --dev eslint-config-cozy-app
 
 ### Usage with a Create Cozy App projects
 
-If you started your project using [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app), you don't need to do anything, you should already have a `.eslintrc.json` configured to used this preset.
+If you started your project using [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app), you don't need to do anything, you should already have an `.eslintrc.json` configured to used this preset.
 
 ### Usage with other projects
 
-In a file named `.eslintrc.json` (the ESLint configuration file), you can use the config using the following way:
+In a file named `.eslintrc.json` (the ESLint configuration file), you can use the config by extending it. For example (see following available configurations documentation):
 
 ```json
 {
     "extends": ["cozy-app"]
 }
 ```
+
+### Available configurations
+
+#### Basics
+
+Basic configuration for common Javascript code, this is the default configuration. To use in your `.eslintrc.json`:
+
+```json
+{
+    "extends": ["cozy-app"]
+}
+```
+
+Or if you want to use it explicitely:
+
+```json
+{
+    "extends": ["cozy-app/basics"]
+}
+```
+
+#### React
+
+Configuration for React applications (basics configuration included). To use in your `.eslintrc.json`:
+
+```json
+{
+    "extends": ["cozy-app/react"]
+}
+```
+
 
 ## Community
 

--- a/packages/eslint-config-cozy-app/basics.js
+++ b/packages/eslint-config-cozy-app/basics.js
@@ -1,0 +1,22 @@
+'use strict'
+
+module.exports = {
+  plugins: ['prettier'],
+  extends: [
+    'eslint:recommended',
+    'eslint-config-prettier'
+  ],
+  parser: 'babel-eslint',
+  env: {
+    browser: true,
+    jest: true,
+    node: true,
+    es6: true
+  },
+  rules: {
+    'prettier/prettier': ['error', {
+      singleQuote: true,
+      semi: false
+    }]
+  }
+}

--- a/packages/eslint-config-cozy-app/index.js
+++ b/packages/eslint-config-cozy-app/index.js
@@ -1,25 +1,3 @@
 'use strict'
 
-module.exports = {
-  plugins: ['prettier'],
-  extends: [
-    'eslint:recommended',
-    'eslint-config-prettier',
-    'plugin:react/recommended'
-  ],
-  parser: 'babel-eslint',
-  parserOptions: { ecmaFeatures: { jsx: true } },
-  env: {
-    browser: true,
-    jest: true,
-    node: true,
-    es6: true
-  },
-  rules: {
-    'prettier/prettier': ['error', {
-      singleQuote: true,
-      semi: false
-    }],
-    'react/prop-types': 0
-  }
-}
+module.exports = require('./basics')

--- a/packages/eslint-config-cozy-app/package.json
+++ b/packages/eslint-config-cozy-app/package.json
@@ -13,7 +13,9 @@
     "url": "https://github.com/CPatchane/create-cozy-app/issues"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "basics.js",
+    "react.js"
   ],
   "dependencies": {
     "babel-eslint": "^8.0.1",

--- a/packages/eslint-config-cozy-app/react.js
+++ b/packages/eslint-config-cozy-app/react.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const basics = require('./basics')
+
+module.exports = {
+  plugins: basics.plugins,
+  extends: [
+    ...basics.extends,
+    'plugin:react/recommended'
+  ],
+  parser: basics.parser,
+  parserOptions: { ecmaFeatures: { jsx: true } },
+  env: basics.env,
+  rules: {
+    ...basics.rules,
+    'react/prop-types': 0
+  }
+}


### PR DESCRIPTION
Two shareable configurations now available:

```javascript
// for main JS code
extends: [ 'cozy-app']
// for react app
extends: ['cozy-app/react']
```

Documentation about multiple configs from a shareable config: https://eslint.org/docs/developer-guide/shareable-configs#sharing-multiple-configs