### PR TITLE
Split presets in babel-preset-cozy-app

### DIFF
--- a/packages/babel-preset-cozy-app/README.md
+++ b/packages/babel-preset-cozy-app/README.md
@@ -20,9 +20,9 @@
 
 ### What's babel-preset-cozy-app?
 
-A shareable configuration for Cozy Application with React and JSX support.
+A shareable configuration for Cozy Applications or Scripts.
 
-This package is a Babel preset used by [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app).
+This package is a Babel preset already used by [`create-cozy-app`](https://github.com/CPatchane/create-cozy-app).
 
 To install:
 
@@ -46,41 +46,21 @@ Then, in a file named `.babelrc` (the Babel configuration file), you can use the
 }
 ```
 
-### Content
+### Options
 
-#### Presets:
+#### `node` (boolean)
 
-- [`env`](https://github.com/babel/babel/tree/master/experimental/babel-preset-env) to add polyfills with the current configuration:
+By default, the babel preset targets browsers but you can target node by passing the option:
 
-    ```javascript
-    {
-      targets: {
-        chrome: 42,
-        ie: 10,
-        firefox: 40,
-        browsers: ['last 2 versions']
-      },
-      useBuiltIns: false
-    }
-    ```
-
-- [`react`](https://babeljs.io/docs/plugins/preset-react/) to support JSX and transform it to `createElement` calls.
-
-#### Plugins:
-
-- [`transform-object-rest-spread`](http://babeljs.io/docs/plugins/transform-object-rest-spread/) to transform rest properties for object destructuring assignment and spread properties for object literals. The `useBuiltIns` options is enable to directly use `Object.assign` considered as available or polyfilled.
-
-- [`transform-class-properties`](https://babeljs.io/docs/plugins/transform-class-properties/) to transform class attributes and methods with auto-binding to the class instance and no constructor needed.
-
-- [`transfor-runtime`](https://babeljs.io/docs/plugins/transform-runtime/) only to polyfill generators (for async/await) here:
-
-    ```js
-    {
-      helpers: false,
-      polyfill: false,
-      regenerator: true
-    }
-    ```
+```json
+{
+    "presets": [
+        ["cozy-app", {
+            "node": true
+        }]
+    ]
+}
+```
 
 ## Community
 

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -1,39 +1,74 @@
 'use strict'
 
-module.exports = {
-  presets: [
-    // Latest ECMAScript features on previous browsers versions
-    [
-      require.resolve('babel-preset-env'),
-      {
-        targets: {
-          chrome: 42,
-          ie: 10,
-          firefox: 40,
-          browsers: ['last 2 versions']
-        },
-        // don't transform polyfills
-        useBuiltIns: false
+const { declare } = require('@babel/helper-plugin-utils')
+
+const browserEnv = {
+  targets: {
+    chrome: 42,
+    ie: 10,
+    firefox: 40,
+    browsers: ['last 2 versions']
+  },
+  // don't transform polyfills
+  useBuiltIns: false
+}
+
+const nodeEnv = {
+  targets: {
+    node: 8
+  },
+  // don't transform polyfills
+  useBuiltIns: false
+}
+
+module.exports = declare((api, options, dirname) => {
+  let node = false
+
+  if (options) {
+    if (options.node) {
+      if (typeof options.node !== 'boolean') {
+        throw new Error("Preset cozy-app 'node' option must be a boolean.")
       }
-    ],
-    // for JSX
-    require.resolve('babel-preset-react')
-  ],
-  plugins: [
-    // Transform rest properties for object destructuring assignment
-    // and spread properties for object literals
-    // useBuiltIns to directly use Object.assign instead of using Babel extends
-    [require.resolve('babel-plugin-transform-object-rest-spread'), {
-      useBuiltIns: false
-    }],
+      node = options.node
+    }
+  }
+
+  const config = {}
+
+  // Latest ECMAScript features on previous browsers versions
+  let env = [require.resolve('babel-preset-env')]
+  if (node) {
+    env.push(nodeEnv)
+  } else {
+    env.push(browserEnv)
+  }
+
+  let presets = [env]
+  // JSX if app
+  if (!node) presets.push(require.resolve('babel-preset-react'))
+  config.presets = presets
+
+  const plugins = [
     // transform class attributes and methods with auto-binding
     // to the class instance and no constructor needed
-    require.resolve('babel-plugin-transform-class-properties'),
-    // Polyfills generator functions (for async/await usage)
-    [require.resolve('babel-plugin-transform-runtime'), {
-      helpers: false,
-      polyfill: false,
-      regenerator: true
-    }]
+    require.resolve('babel-plugin-transform-class-properties')
   ]
-}
+  if (!node) {
+    plugins.push(
+      // Transform rest properties for object destructuring assignment
+      // and spread properties for object literals
+      // useBuiltIns to directly use Object.assign instead of using Babel extends
+      [require.resolve('babel-plugin-transform-object-rest-spread'), {
+        useBuiltIns: false
+      }],
+      // Polyfills generator functions (for async/await usage)
+      [require.resolve('babel-plugin-transform-runtime'), {
+        helpers: false,
+        polyfill: false,
+        regenerator: true
+      }]
+    )
+  }
+  config.plugins = plugins
+  return config
+})

--- a/packages/babel-preset-cozy-app/package.json
+++ b/packages/babel-preset-cozy-app/package.json
@@ -16,6 +16,7 @@
     "index.js"
   ],
   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.0.0-beta.46",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",

--- a/packages/babel-preset-cozy-app/yarn.lock
+++ b/packages/babel-preset-cozy-app/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@babel/helper-plugin-utils@^7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.46.tgz#f630adbd9d645d0ba2e43f4955b4ad61f44ccdf4"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
Now you can pass an option to target Node instead of browsers for transpiling: 

```json
{
    "presets": [
        ["cozy-app", {
            "node": true
        }]
    ]
}
```

Preset options documentation: https://babeljs.io/docs/plugins/#pluginpreset-options and https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils/src#babelhelper-plugin-utils