### PR TITLE
Better usage of babel-preset cozy-app for `.js` files

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -24,7 +24,10 @@ module.exports = {
         exclude: /(node_modules|cozy-(bar|client-js))/,
         loader: 'babel-loader',
         options: {
-          cacheDirectory: 'node_modules/.cache/babel-loader'
+          cacheDirectory: 'node_modules/.cache/babel-loader',
+          presets: [
+            ['cozy-app', { react: false }]
+          ]
         }
       },
       {

--- a/packages/cozy-scripts/config/webpack.config.services.js
+++ b/packages/cozy-scripts/config/webpack.config.services.js
@@ -55,7 +55,7 @@ const config = {
           cacheDirectory: 'node_modules/.cache/babel-loader',
           babelrc: false,
           presets: [
-            ['cozy-app', { node: true }]
+            ['cozy-app', { node: true, react: false }]
           ]
         }
       },

--- a/packages/cozy-scripts/template-vue/app/.babelrc
+++ b/packages/cozy-scripts/template-vue/app/.babelrc
@@ -1,3 +1,5 @@
 {
-  "presets": ["cozy-app"]
+  "presets": [
+    ["cozy-app", { "react": false }]
+  ]
 }

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -21,6 +21,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -329,6 +337,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -628,6 +644,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -941,6 +965,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -1248,6 +1280,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -1557,6 +1597,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -102,6 +102,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -453,6 +461,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -795,6 +811,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -1151,6 +1175,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -1501,6 +1533,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -1853,6 +1893,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -2254,6 +2302,14 @@ Array [
           "loader": "babel-loader",
           "options": Object {
             "cacheDirectory": "node_modules/.cache/babel-loader",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "react": false,
+                },
+              ],
+            ],
           },
           "test": Object {},
         },
@@ -2616,6 +2672,7 @@ Array [
                 "cozy-app",
                 Object {
                   "node": true,
+                  "react": false,
                 },
               ],
             ],


### PR DESCRIPTION
Disable `react` needs for these files.