### PR TITLE
Add buggy asked eslint-plugin-prettier

### DIFF
--- a/packages/cozy-scripts/template-vue/package.json
+++ b/packages/cozy-scripts/template-vue/package.json
@@ -43,6 +43,7 @@
     "babel-polyfill": "6.26.0",
     "babel-preset-cozy-app": "0.8.0",
     "eslint": "4.19.1",
+    "eslint-plugin-prettier": "^2.6.0",
     "git-directory-deploy": "1.5.1",
     "jest-serializer-vue": "1.0.0",
     "npm-run-all": "4.1.3",

--- a/packages/cozy-scripts/template/package.json
+++ b/packages/cozy-scripts/template/package.json
@@ -44,6 +44,7 @@
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "eslint": "4.19.1",
+    "eslint-plugin-prettier": "^2.6.0",
     "git-directory-deploy": "1.5.1",
     "npm-run-all": "4.1.3",
     "prettier": "1.12.1",


### PR DESCRIPTION
For some weird reasons, `eslint-plugin-prettier` is missing in the application modules. Let's add it to the package while figuring out this issue.