### PR TITLE
feat: HTML title from manifest

### DIFF
--- a/packages/cozy-scripts/config/webpack.target.browser.js
+++ b/packages/cozy-scripts/config/webpack.target.browser.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const fs = require('fs')
+const fs = require('fs-extra')
 const webpack = require('webpack')
 const paths = require('../utils/paths')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const manifest = JSON.parse(fs.readFileSync(paths.appManifest).toString())
+const manifest = fs.readJsonSync(paths.appManifest)
 
 module.exports = {
   entry: {

--- a/packages/cozy-scripts/config/webpack.target.browser.js
+++ b/packages/cozy-scripts/config/webpack.target.browser.js
@@ -1,9 +1,10 @@
 'use strict'
 
+const fs = require('fs')
 const webpack = require('webpack')
 const paths = require('../utils/paths')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const pkg = require(paths.appPackageJson)
+const manifest = JSON.parse(fs.readFileSync(paths.appManifest).toString())
 
 module.exports = {
   entry: {
@@ -21,7 +22,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: paths.appBrowserHtmlTemplate,
-      title: pkg.name,
+      title: manifest.name,
       inject: false,
       chunks: ['app'],
       minify: {


### PR DESCRIPTION
`name` in `package.json` is often in slug form like "cozy-contacts"
`name` in `manifest.webapp` is the one used in the store so it has a more humane form.