### PR TITLE
Use the correct app name for html titles

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.intents.js
+++ b/packages/cozy-scripts/config/webpack.config.intents.js
@@ -3,7 +3,11 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
-const pkg = require(paths.appPackageJson)
+const manifest = fs.readJsonSync(paths.appManifest)
+
+const appName = manifest.name_prefix
+  ? `${manifest.name_prefix} ${manifest.name}`
+  : manifest.name
 
 function getConfig () {
   return (fs.existsSync(paths.appIntentsIndex()) &&
@@ -17,7 +21,7 @@ function getConfig () {
       plugins: [
         new HtmlWebpackPlugin({
           template: paths.appIntentsHtmlTemplate,
-          title: `${pkg.name} intents`,
+          title: `${appName} intents`,
           filename: 'intents/index.html',
           inject: false,
           chunks: ['intents'],

--- a/packages/cozy-scripts/config/webpack.target.browser.js
+++ b/packages/cozy-scripts/config/webpack.target.browser.js
@@ -6,6 +6,10 @@ const paths = require('../utils/paths')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const manifest = fs.readJsonSync(paths.appManifest)
 
+const appName = manifest.name_prefix
+  ? `${manifest.name_prefix} ${manifest.name}`
+  : manifest.name
+
 module.exports = {
   entry: {
     // since the file extension depends on the framework here
@@ -22,7 +26,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: paths.appBrowserHtmlTemplate,
-      title: manifest.name,
+      title: appName,
       inject: false,
       chunks: ['app'],
       minify: {

--- a/packages/cozy-scripts/config/webpack.target.mobile.js
+++ b/packages/cozy-scripts/config/webpack.target.mobile.js
@@ -1,11 +1,16 @@
 'use strict'
 
+const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 const {production} = require('./webpack.vars')
-const pkg = require(paths.appPackageJson)
+const manifest = fs.readJsonSync(paths.appManifest)
+
+const appName = manifest.name_prefix
+  ? `${manifest.name_prefix} ${manifest.name}`
+  : manifest.name
 
 module.exports = {
   entry: {
@@ -20,7 +25,7 @@ module.exports = {
     new webpack.DefinePlugin({
       __ALLOW_HTTP__: !production,
       __TARGET__: JSON.stringify('mobile'),
-      __APP_VERSION__: JSON.stringify(pkg.version)
+      __APP_VERSION__: JSON.stringify(manifest.version)
     }),
     new webpack.ProvidePlugin({
       'cozy.client': production ? 'cozy-client-js/dist/cozy-client.min.js' : 'cozy-client-js/dist/cozy-client.js',
@@ -28,7 +33,7 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       template: paths.appMobileHtmlTemplate,
-      title: pkg.name,
+      title: appName,
       chunks: ['app'],
       inject: 'head',
       minify: {


### PR DESCRIPTION
Use the app name with the prefix (if exists) for all HTML titles.