### PR TITLE
Exclude cozy-client from webpack babel config

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -21,7 +21,7 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        exclude: /(node_modules|cozy-(bar|client-js))/,
+        exclude: /(node_modules|cozy-(bar|client|client-js))/,
         loader: require.resolve('babel-loader'),
         options: {
           cacheDirectory: 'node_modules/.cache/babel-loader/js',


### PR DESCRIPTION
When adding cozy-client into a cozy app, yarn was unable to compile cozy-client.