### PR TITLE
fix: Docker unlink folder 🐛

### DIFF
--- a/packages/cozy-scripts/utils/cleanBuild.js
+++ b/packages/cozy-scripts/utils/cleanBuild.js
@@ -5,9 +5,9 @@ const paths = require('./paths')
 
 module.exports = target => {
   if (target === 'mobile') {
-    if (fs.existsSync(paths.appMobileWWW)) fs.removeSync(paths.appMobileWWW)
+    fs.emptyDir(paths.appMobileWWW)
   } else if (target === 'browser') {
-    if (fs.existsSync(paths.appBuild)) fs.removeSync(paths.appBuild)
+    fs.emptyDir(paths.appBuild)
   } else {
     console.warn(`No build folder found to clean (target ${target}).`)
   }


### PR DESCRIPTION
Unnecessary to test if folder exist because fs-extra is [extra](https://github.com/jprichardson/node-fs-extra/blob/master/docs/emptyDir.md).

fix #644