### PR TITLE
Add transformRegenerator option to babel-preset-coz-app

### DIFF
--- a/packages/babel-preset-cozy-app/README.md
+++ b/packages/babel-preset-cozy-app/README.md
@@ -76,6 +76,20 @@ By default, this babel preset uses the `react` preset ([`babel-preset-react`](ht
 }
 ```
 
+#### `transformRegenerator` (boolean): `true` by default (for browsers only)
+
+By default, this babel preset uses [`babel-plugin-transform-runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime.html) to transform regenerator functions on the runtime. But sometimes (not always) it could break CSPs due to some eval usage so you can disable this behaviour with the `transformRegenerator` option to `false` as following:
+
+```json
+{
+    "presets": [
+        ["cozy-app", {
+            "transformRegenerator": false
+        }]
+    ]
+}
+```
+
 ## Community
 
 ### What's Cozy?

--- a/packages/babel-preset-cozy-app/index.js
+++ b/packages/babel-preset-cozy-app/index.js
@@ -23,23 +23,24 @@ const nodeEnv = {
 
 module.exports = declare((api, options, dirname) => {
   // default options
-  let node = false
-  let react = true
+  let presetOptions = {
+    node: false,
+    react: true,
+    transformRegenerator: true
+  }
 
   if (options) {
-    if (options.node) {
-      if (typeof options.node !== 'boolean') {
-        throw new Error("Preset cozy-app 'node' option must be a boolean.")
+    for (let option in presetOptions) {
+      if (options.hasOwnProperty(option)) {
+        if (typeof options[option] !== 'boolean') {
+          throw new Error(`Preset cozy-app '${option}' option must be a boolean.`)
+        }
+        presetOptions[option] = options[option]
       }
-      node = options.node
-    }
-    if (options.react) {
-      if (typeof options.react !== 'boolean') {
-        throw new Error("Preset cozy-app 'react' option must be a boolean.")
-      }
-      react = options.react
     }
   }
+
+  const { node, react, transformRegenerator } = presetOptions
 
   const config = {}
 
@@ -67,7 +68,7 @@ module.exports = declare((api, options, dirname) => {
       useBuiltIns: false
     }]
   ]
-  if (!node) {
+  if (!node && transformRegenerator) {
     plugins.push(
       // Polyfills generator functions (for async/await usage)
       [require.resolve('babel-plugin-transform-runtime'), {


### PR DESCRIPTION
Sometimes it could break CSPs, so this adds a way to disable it.