### PR TITLE
Disable removeViewBox from SVGO

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.vendors.js
+++ b/packages/cozy-scripts/config/webpack.config.vendors.js
@@ -5,7 +5,13 @@ const SvgoInstance = require('svgo')
 const paths = require('../utils/paths')
 const fs = require('fs')
 
-const svgo = new SvgoInstance()
+const svgo = new SvgoInstance({
+  plugins: [
+    {
+      removeViewBox: false
+    }
+  ]
+})
 
 let iconName
 try {


### PR DESCRIPTION
SVGO is removing viewBox attributes from SVG icon but if this attribute is missing, the icon may be rendered vertically stretched.

![image_ 1](https://user-images.githubusercontent.com/776764/44599006-34c50580-a7d5-11e8-896a-67fa0a864b40.png)
