### PR TITLE
Add `stack:nocsp` app script for HMR

### DIFF
--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -66,6 +66,7 @@
     "bin",
     "config",
     "scripts",
+    "stack",
     "utils",
     "template/app",
     "template/.travis.yml",

--- a/packages/cozy-scripts/stack/disableCSP.yaml
+++ b/packages/cozy-scripts/stack/disableCSP.yaml
@@ -1,0 +1,9 @@
+# This a config file for cozy-stack used to disable CSPs
+# in order to allow Hot Module Reloading using Webpack Dev Server
+# BE AWARE that is usable only using the dev version of cozy-stack
+# You will ALWAYS have CSPs working on a real Cozy
+# so your final application must work with them on
+disable_csp: true
+
+# You can find a complete example of the cozy-stack config file here:
+# https://github.com/cozy/cozy-stack/blob/master/cozy.example.yaml

--- a/packages/cozy-scripts/template-vue/package.json
+++ b/packages/cozy-scripts/template-vue/package.json
@@ -19,7 +19,8 @@
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git}",
     "pretest": "yarn lint",
     "test": "cozy-scripts test --verbose --coverage",
-    "stack:docker": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev",
+    "stack": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev",
+    "stack:nocsp": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app -v \"$(pwd)/node_modules/cozy-scripts/stack/disableCSP.yaml\":/etc/cozy/cozy.yaml cozy/cozy-app-dev",
     "cozyPublish": "git fetch origin ${DEPLOY_BRANCH:-build}:${DEPLOY_BRANCH:-build} && cozy-scripts publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})"
   },
   "repository": {

--- a/packages/cozy-scripts/template/package.json
+++ b/packages/cozy-scripts/template/package.json
@@ -19,7 +19,8 @@
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/<USERNAME_GH>/<SLUG_GH>.git}",
     "pretest": "yarn lint",
     "test": "cozy-scripts test --verbose --coverage",
-    "stack:docker": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev",
+    "stack": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app cozy/cozy-app-dev",
+    "stack:nocsp": "docker run --rm -it -p 8080:8080 -p 5984:5984 -v \"$(pwd)/build\":/data/cozy-app/app -v \"$(pwd)/node_modules/cozy-scripts/stack/disableCSP.yaml\":/etc/cozy/cozy.yaml cozy/cozy-app-dev",
     "cozyPublish": "git fetch origin ${DEPLOY_BRANCH:-build}:${DEPLOY_BRANCH:-build} && cozy-scripts publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})"
   },
   "repository": {


### PR DESCRIPTION
Since CSPs break hot reloading we have to disable them. 
This PR add a dedicated config file and an app script to launch the stack using Docker with CSPs disabled