### PR TITLE
Provide __SSL__ webpack plugin

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -12,6 +12,7 @@ const buildCozyBarCss = `${paths.appBuild}/cozy-bar.css`
 let plugins = [
   new webpack.DefinePlugin({
     __DEVELOPMENT__: true,
+    __SSL__: false,
     __STACK_ASSETS__: false
   }),
   new webpack.ProvidePlugin({

--- a/packages/cozy-scripts/config/webpack.environment.prod.js
+++ b/packages/cozy-scripts/config/webpack.environment.prod.js
@@ -11,6 +11,7 @@ module.exports = {
       'process.env.NODE_ENV': JSON.stringify('production'), // to compile on production mode (redux)
       __DEVELOPMENT__: false,
       __DEVTOOLS__: false,
+      __SSL__: true,
       __STACK_ASSETS__: target !== 'mobile'
     })
   ]


### PR DESCRIPTION
This webpack plugin have the value `false` in a development environment and `true` in a production environment.

The idea is to be able to provide a configured value for every library needing to be initialized with a `ssl` parameter, and not relying on hacks based on window.location or passed URLs for example.

By providing this webpack plugin we can configure libraries with SSL. The value is false in a dev environment en true in a production environment.