### PR TITLE
Add missing postcss-discard-empty dependency

### DIFF
--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -42,6 +42,7 @@
     "postcss": "7.0.5",
     "postcss-assets-webpack-plugin": "3.0.0",
     "postcss-discard-duplicates": "4.0.2",
+    "postcss-discard-empty": "4.0.1",
     "postcss-loader": "3.0.0",
     "progress": "2.0.0",
     "prompt": "1.0.0",
@@ -82,8 +83,5 @@
     "template-vue/package.json",
     "template-vue/README.md",
     "template-vue/yarn.lock"
-  ],
-  "devDependencies": {
-    "postcss-discard-empty": "4.0.1"
-  }
+  ]
 }


### PR DESCRIPTION
The dependency was not in the `dependencies` field of the package.json but in `devDependencies`