### PR TITLE
Always write files on dev mode

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -28,18 +28,22 @@ let plugins = [
     assets: ['cozy-bar.css'],
     append: false,
     publicPath: true
+  }),
+  /*
+  Here is the trick about hot-reload:
+  We launch a webpack-dev-server but we write the computed build files to the disk to allow running `cozy-stack server` on them.
+  */
+  new WriteFilePlugin({
+    exitOnErrors: false,
+    // Copy only assets on disk, other files will be from memory (dev-server)
+    // .js and .css files are more likely to be changed
+    // than assets during development
+    test: /(?!(\.js|\.css))$/
   })
 ]
 
 if (useHotReload) {
-  plugins = plugins.concat([
-    new webpack.HotModuleReplacementPlugin(),
-    /*
-    Here is the trick about hot-reload:
-    We launch a webpack-dev-server but we write the computed build files to the disk to allow running `cozy-stack server` on them.
-    */
-    new WriteFilePlugin()
-  ])
+  plugins = plugins.concat([new webpack.HotModuleReplacementPlugin()])
 }
 
 module.exports = {

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -336,6 +336,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [
@@ -1034,6 +1035,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [
@@ -1729,6 +1731,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [
@@ -2084,6 +2087,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -431,6 +431,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [
@@ -1201,6 +1202,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [
@@ -1968,6 +1970,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [
@@ -2359,6 +2362,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [
@@ -2814,6 +2818,7 @@ Array [
           "publicPath": true,
         },
       },
+      Object {},
     ],
     "resolve": Object {
       "extensions": Array [


### PR DESCRIPTION
We should always write files on disk when developing since we can run `start` without `--hot` and it will break the docker part (because assets not found).
The write plugin now only writes assets (no `.js` and `.css` files) to be able to run the docker stack correctly while keeping using build files (css,js) from the memory.