### PR TITLE
Don't change state of unmounted component in React template

### DIFF
--- a/packages/cozy-scripts/template/app/src/components/Todos/TodoRemoveButton.jsx
+++ b/packages/cozy-scripts/template/app/src/components/Todos/TodoRemoveButton.jsx
@@ -18,7 +18,9 @@ export class TodoRemoveButton extends Component {
     // delete the todo in the Cozy : asynchronous
     await deleteDocument(todo)
     // remove the spinner
-    this.setState(() => ({ isWorking: false }))
+    // this.setState(() => ({ isWorking: false }))
+    // We can omit that since this component will be
+    // unmount after the document is deleted by the client
   }
 
   render() {


### PR DESCRIPTION
There was a message of React saying that we try to change the state of an unmounted component. Here the component is unmounted by update when the client has deleted the document.