### PR TITLE
 Use the correct folder name in finish logs

### DIFF
--- a/packages/cozy-scripts/scripts/init.js
+++ b/packages/cozy-scripts/scripts/init.js
@@ -203,7 +203,7 @@ function run(appPath, dataMap, cliOptions, gracefulRootExit, successCallback) {
       )
       console.log()
       console.log('Next steps:')
-      console.log(`  $ ${colorize.bold(`cd ${dataMap.get('<SLUG_GH>')}`)}`)
+      console.log(`  $ ${colorize.bold(`cd ${path.basename(appPath)}`)}`)
       console.log(`  $ ${colorize.bold('yarn start')}`)
       if (typeof successCallback === 'function') successCallback()
     })


### PR DESCRIPTION
The slug can be different from the folder name