### PR TITLE
Use paths as functions + handle more CLI path options

### DIFF
--- a/packages/cozy-scripts/README.md
+++ b/packages/cozy-scripts/README.md
@@ -227,6 +227,14 @@ Use this option if you want to analyze your builds content using the webpack plu
 Use this option if you want to run `cozy-scripts start` without launching the Cozy stack using docker. You will only have Webpack watching with `webpack-dev-server`.
 It could be useful if you already have a Cozy stack running elsewhere in your environment.
 
+##### - Custom paths providing options: `--src-dir`, `--build-dir`, `--manifest`
+
+Use these options if you want to `build`/`watch`/`start` your application with custom paths. These paths __must be relative to the application root directory__:
+
+- `--src-dir`: the `src` directory, the source files of your application
+- `--build-dir`: the directory to put the application build files into
+- `--manifest`: the path of your manifest file `manifest.webapp` (the `.webapp` extension must be provided)
+
 ### The `cozy-scripts` webpack configuration
 
 `cozy-scripts` is designed to use a default webpack configuration for a basic React/Redux (or VueJS) application which uses `cozy-ui` and `cozy-client-js`. But you can override or use your custom configuration files by creating a new `app.config.js` file in your application root folder. Here is an example to overload the default bundle config with a custom one:

--- a/packages/cozy-scripts/bin/cozy-scripts.js
+++ b/packages/cozy-scripts/bin/cozy-scripts.js
@@ -40,6 +40,18 @@ const program = new commander.Command(pkg.name)
   .option('--show-config', 'just print app final webpack config')
   .option('--vue', 'to use scripts in a VueJS specific way (default React)')
   .option(
+    '--src-dir <pathToDirectory>',
+    'provide the application source (`src`) directory path (relative to the application root directory)'
+  )
+  .option(
+    '--build-dir <pathToDirectory>',
+    'provide the application `build` directory path (relative to the application root directory) to build the application into'
+  )
+  .option(
+    '--manifest <pathToFile>',
+    'provide the application manifest file path (relative to the application root directory)'
+  )
+  .option(
     '--analyzer',
     'open an analyzer with an interactive treemap visualization of the contents of all builds'
   )
@@ -65,7 +77,10 @@ const options = {
 ;[
   ['hot', 'HOT_RELOAD', true],
   ['fix', 'COZY_SCRIPTS_ESLINT_FIX', true],
-  ['debug', 'COZY_SCRIPTS_DEBUG', true]
+  ['debug', 'COZY_SCRIPTS_DEBUG', true],
+  ['srcDir', 'COZY_SCRIPTS_APP_SRC_DIR', program.srcDir],
+  ['buildDir', 'COZY_SCRIPTS_APP_BUILD_DIR', program.buildDir],
+  ['manifest', 'COZY_SCRIPTS_APP_MANIFEST', program.manifest]
 ].map(toDefine => {
   if (program[toDefine[0]]) process.env[toDefine[1]] = toDefine[2]
 })

--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -15,7 +15,7 @@ const production = environment === 'production'
 
 module.exports = {
   resolve: {
-    modules: [paths.appSrc, paths.appNodeModules],
+    modules: [paths.appSrc(), paths.appNodeModules()],
     extensions: ['.js', '.json', '.css'],
     // linked package will still be see as a node_modules package
     symlinks: false

--- a/packages/cozy-scripts/config/webpack.config.cozy-ui.js
+++ b/packages/cozy-scripts/config/webpack.config.cozy-ui.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const paths = require('../utils/paths')
-const cozyUIPlugin = require(paths.appCozyUiStylus)
+const cozyUIPlugin = require(paths.appCozyUiStylus())
 const SpriteLoaderPlugin = require('svg-sprite-loader/plugin')
 const { getCSSLoader } = require('./webpack.vars')
 

--- a/packages/cozy-scripts/config/webpack.config.cozy-ui.react.js
+++ b/packages/cozy-scripts/config/webpack.config.cozy-ui.react.js
@@ -2,7 +2,7 @@
 
 const { getCSSLoader } = require('./webpack.vars')
 const paths = require('../utils/paths')
-const cozyUIPlugin = require(paths.appCozyUiStylus)
+const cozyUIPlugin = require(paths.appCozyUiStylus())
 
 module.exports = {
   module: {

--- a/packages/cozy-scripts/config/webpack.config.hash.js
+++ b/packages/cozy-scripts/config/webpack.config.hash.js
@@ -13,7 +13,7 @@ module.exports = {
     function() {
       this.plugin('done', stats => {
         fs.writeFileSync(
-          path.join(targetConfig.output.path, paths.appBuildAssetsJson),
+          path.join(targetConfig.output.path, paths.appBuildAssetsJson()),
           `{"hash":"${stats.hash}"}`
         )
       })

--- a/packages/cozy-scripts/config/webpack.config.intents.js
+++ b/packages/cozy-scripts/config/webpack.config.intents.js
@@ -3,7 +3,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
-const manifest = fs.readJsonSync(paths.appManifest)
+const manifest = fs.readJsonSync(paths.appManifest())
 
 const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
@@ -11,7 +11,7 @@ const appName = manifest.name_prefix
 
 function getConfig() {
   return fs.existsSync(paths.appIntentsIndex()) &&
-    fs.existsSync(paths.appIntentsHtmlTemplate)
+    fs.existsSync(paths.appIntentsHtmlTemplate())
     ? {
         entry: {
           // since the file extension depends on the framework here
@@ -20,7 +20,7 @@ function getConfig() {
         },
         plugins: [
           new HtmlWebpackPlugin({
-            template: paths.appIntentsHtmlTemplate,
+            template: paths.appIntentsHtmlTemplate(),
             title: `${appName} intents`,
             filename: 'intents/index.html',
             inject: false,

--- a/packages/cozy-scripts/config/webpack.config.manifest.js
+++ b/packages/cozy-scripts/config/webpack.config.manifest.js
@@ -19,9 +19,9 @@ module.exports = {
   },
   plugins: [
     new CopyPlugin([
-      { from: paths.appManifest, transform: transformManifest },
-      { from: paths.appREADME },
-      { from: paths.appLICENSE }
+      { from: paths.appManifest(), transform: transformManifest },
+      { from: paths.appREADME() },
+      { from: paths.appLICENSE() }
     ])
   ]
 }
@@ -37,11 +37,11 @@ module.exports = {
 function transformManifest(buffer) {
   const content = JSON.parse(buffer.toString())
   if (environment === 'production') {
-    const locales = fs.readdirSync(paths.appLocales)
+    const locales = fs.readdirSync(paths.appLocales())
     content.locales = {}
     content.langs = []
     for (const idx in locales) {
-      const localContent = require(path.join(paths.appLocales, locales[idx]))
+      const localContent = require(path.join(paths.appLocales(), locales[idx]))
       const lang = locales[idx].match(/^([^.]*).json$/)[1]
       content.locales[lang] = localContent.manifest ? localContent.manifest : {}
       content.langs.push(lang)

--- a/packages/cozy-scripts/config/webpack.config.services.js
+++ b/packages/cozy-scripts/config/webpack.config.services.js
@@ -6,7 +6,7 @@ const webpack = require('webpack')
 const paths = require('../utils/paths')
 const { eslintFix, getFilename, target } = require('./webpack.vars')
 
-const servicesFolder = paths.appServicesFolder
+const servicesFolder = paths.appServicesFolder()
 const servicesPaths = fs.readdirSync(servicesFolder)
 
 const servicesEntries = {}
@@ -29,7 +29,7 @@ const config = {
   },
   entry: servicesEntries,
   output: {
-    path: paths.appServicesBuild,
+    path: paths.appServicesBuild(),
     filename: `${getFilename()}.js`
   },
   target: 'node',

--- a/packages/cozy-scripts/config/webpack.config.vendors.js
+++ b/packages/cozy-scripts/config/webpack.config.vendors.js
@@ -15,7 +15,7 @@ const svgo = new SvgoInstance({
 
 let iconName
 try {
-  iconName = JSON.parse(fs.readFileSync(paths.appManifest, 'utf8')).icon
+  iconName = JSON.parse(fs.readFileSync(paths.appManifest(), 'utf8')).icon
   // we run optimize only on SVG
   if (!iconName.match(/\.svg$/)) iconName = null
 } catch (e) {
@@ -33,7 +33,7 @@ function optimizeSVGIcon(buffer, path) {
 module.exports = {
   plugins: [
     new CopyPlugin([
-      { from: paths.appVendorAssets, transform: optimizeSVGIcon }
+      { from: paths.appVendorAssets(), transform: optimizeSVGIcon }
     ])
   ]
 }

--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -6,9 +6,9 @@ const HtmlWebpackIncludeAssetsPlugin = require('html-webpack-include-assets-plug
 const CopyPlugin = require('copy-webpack-plugin')
 const { useHotReload } = require('./webpack.vars')
 
-const buildCozyBarCss = `${paths.appBuild}/cozy-bar.css`
-const buildCozyBarJs = `${paths.appBuild}/cozy-bar.js`
-const buildCozyClientJs = `${paths.appBuild}/cozy-client-js.js`
+const buildCozyBarCss = `${paths.appBuild()}/cozy-bar.css`
+const buildCozyBarJs = `${paths.appBuild()}/cozy-bar.js`
+const buildCozyClientJs = `${paths.appBuild()}/cozy-client-js.js`
 
 let plugins = [
   new webpack.DefinePlugin({
@@ -17,15 +17,15 @@ let plugins = [
   }),
   new CopyPlugin([
     {
-      from: paths.appCozyBarJs,
+      from: paths.appCozyBarJs(),
       to: buildCozyBarJs
     },
     {
-      from: paths.appCozyBarCss,
+      from: paths.appCozyBarCss(),
       to: buildCozyBarCss
     },
     {
-      from: paths.appCozyClientJs,
+      from: paths.appCozyClientJs(),
       to: buildCozyClientJs
     }
   ]),

--- a/packages/cozy-scripts/config/webpack.target.browser.js
+++ b/packages/cozy-scripts/config/webpack.target.browser.js
@@ -6,7 +6,7 @@ const paths = require('../utils/paths')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 const { getFilename, isDebugMode } = require('./webpack.vars')
-const manifest = fs.readJsonSync(paths.appManifest)
+const manifest = fs.readJsonSync(paths.appManifest())
 
 const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
@@ -18,14 +18,16 @@ module.exports = {
       // polyfills, avaid to import it in the application
       require.resolve('babel-polyfill'),
       // Exposed variables in global scope (needed for cozy-bar)
-      process.env.__USE_PREACT__ ? paths.csPreactExposer : paths.csReactExposer,
+      process.env.__USE_PREACT__
+        ? paths.csPreactExposer()
+        : paths.csReactExposer(),
       // since the file extension depends on the framework here
       // we get it from a function call
       paths.appBrowserIndex()
     ]
   },
   output: {
-    path: paths.appBuild,
+    path: paths.appBuild(),
     filename: `${getFilename()}.js`,
     pathinfo: isDebugMode
   },
@@ -34,7 +36,7 @@ module.exports = {
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: paths.appBrowserHtmlTemplate,
+      template: paths.appBrowserHtmlTemplate(),
       title: appName,
       inject: false,
       excludeChunks: ['intents'],

--- a/packages/cozy-scripts/config/webpack.target.mobile.js
+++ b/packages/cozy-scripts/config/webpack.target.mobile.js
@@ -7,7 +7,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 
 const { production, isDebugMode } = require('./webpack.vars')
-const manifest = fs.readJsonSync(paths.appManifest)
+const manifest = fs.readJsonSync(paths.appManifest())
 
 const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
@@ -20,7 +20,7 @@ module.exports = {
     app: [require.resolve('babel-polyfill'), paths.appMobileIndex()]
   },
   output: {
-    path: paths.appMobileWWW,
+    path: paths.appMobileWWW(),
     pathinfo: isDebugMode
   },
   plugins: [
@@ -38,7 +38,7 @@ module.exports = {
         : 'cozy-bar/dist/cozy-bar.mobile.js'
     }),
     new HtmlWebpackPlugin({
-      template: paths.appMobileHtmlTemplate,
+      template: paths.appMobileHtmlTemplate(),
       title: appName,
       excludeChunks: ['intents'],
       inject: 'head',

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -4,7 +4,7 @@ const colorize = require('../utils/_colorize')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
-const manifest = fs.readJsonSync(paths.appManifest)
+const manifest = fs.readJsonSync(paths.appManifest())
 
 // default NODE_ENV to browser development
 if (!process.env.NODE_ENV) process.env.NODE_ENV = 'browser:development'

--- a/packages/cozy-scripts/scripts/lint.js
+++ b/packages/cozy-scripts/scripts/lint.js
@@ -6,7 +6,7 @@ const paths = require('../utils/paths')
 function runESLint(options) {
   const { cliArgs } = options
 
-  spawn.sync(paths.csEslintBinary, cliArgs, { stdio: 'inherit' })
+  spawn.sync(paths.csEslintBinary(), cliArgs, { stdio: 'inherit' })
 }
 
 module.exports = runESLint

--- a/packages/cozy-scripts/scripts/start.js
+++ b/packages/cozy-scripts/scripts/start.js
@@ -10,8 +10,8 @@ const paths = require('../utils/paths')
 const getWebpackConfigs = require('./config')
 
 let appManifest = null
-if (fs.pathExistsSync(paths.appManifest)) {
-  appManifest = fs.readJsonSync(paths.appManifest, { throws: false })
+if (fs.pathExistsSync(paths.appManifest())) {
+  appManifest = fs.readJsonSync(paths.appManifest(), { throws: false })
 }
 
 const port = process.env.DEV_PORT || '8888'
@@ -168,13 +168,13 @@ module.exports = buildOptions => {
             '-p',
             `${MailHogPort}:8025`,
             '-v',
-            `${paths.appBuild}:/data/cozy-app/${appSlug}`,
+            `${paths.appBuild()}:/data/cozy-app/${appSlug}`,
             '-v',
-            `${paths.csDisableCSPConfig}:/etc/cozy/cozy.yaml`,
+            `${paths.csDisableCSPConfig()}:/etc/cozy/cozy.yaml`,
             'cozy/cozy-app-dev'
           ],
           {
-            cwd: paths.appPath
+            cwd: paths.appPath()
           }
         )
         dockerProcess.stdout.on('data', data => {
@@ -239,7 +239,7 @@ module.exports = buildOptions => {
         console.log(colorize.cyan('See you soon! 👋'))
         dockerProcess.stdout.destroy()
         dockerProcess.stderr.destroy()
-        spawn.sync('sh', ['-c', paths.csQuitStackScript], {
+        spawn.sync('sh', ['-c', paths.csQuitStackScript()], {
           stdio: 'inherit'
         })
       } else {

--- a/packages/cozy-scripts/test/__snapshots__/cli.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/cli.spec.js.snap
@@ -87,6 +87,20 @@ Object {
 }
 `;
 
+exports[`cozy-scripts (cs) CLI should handle build directory path providing with --build-dir option 1`] = `
+Object {
+  "bundleAnalyzer": undefined,
+  "cliArgs": Array [
+    "--build-dir",
+    "custom/app/buildHere",
+  ],
+  "debugMode": undefined,
+  "mode": "development",
+  "target": "browser",
+  "useVue": undefined,
+}
+`;
+
 exports[`cozy-scripts (cs) CLI should handle debug mode with --debug option 1`] = `
 Object {
   "bundleAnalyzer": undefined,
@@ -115,6 +129,20 @@ Object {
 }
 `;
 
+exports[`cozy-scripts (cs) CLI should handle manifest path providing with --manifest option 1`] = `
+Object {
+  "bundleAnalyzer": undefined,
+  "cliArgs": Array [
+    "--manifest",
+    "custom/app/manifest.webapp",
+  ],
+  "debugMode": undefined,
+  "mode": "development",
+  "target": "browser",
+  "useVue": undefined,
+}
+`;
+
 exports[`cozy-scripts (cs) CLI should handle mobile target with --mobile option 1`] = `
 Object {
   "bundleAnalyzer": undefined,
@@ -129,6 +157,20 @@ Object {
 `;
 
 exports[`cozy-scripts (cs) CLI should handle previous \`standalone\` command to display a message to use \`start\` instead 1`] = `" ⚠️ \`cozy-scripts standalone\` has been replaced. Please use \`cozy-scripts start\` instead. ⚠️ "`;
+
+exports[`cozy-scripts (cs) CLI should handle src directory path providing with --src-dir option 1`] = `
+Object {
+  "bundleAnalyzer": undefined,
+  "cliArgs": Array [
+    "--src-dir",
+    "custom/app/src",
+  ],
+  "debugMode": undefined,
+  "mode": "development",
+  "target": "browser",
+  "useVue": undefined,
+}
+`;
 
 exports[`cozy-scripts (cs) CLI should run start script on \`start\` command with all passed options with development mode by default 1`] = `
 Object {

--- a/packages/cozy-scripts/test/cli.spec.js
+++ b/packages/cozy-scripts/test/cli.spec.js
@@ -72,9 +72,12 @@ describe('cozy-scripts (cs) CLI', () => {
     // clean args list
     process.argv = [process.execPath, path.resolve('../bin/cozy-scripts')]
     // default env
-    process.env.HOT_RELOAD = 'false'
-    process.env.COZY_SCRIPTS_DEBUG = 'false'
-    process.env.COZY_SCRIPTS_ESLINT_FIX = 'false'
+    process.env.HOT_RELOAD = undefined
+    process.env.COZY_SCRIPTS_DEBUG = undefined
+    process.env.COZY_SCRIPTS_ESLINT_FIX = undefined
+    process.env.COZY_SCRIPTS_APP_SRC_DIR = undefined
+    process.env.COZY_SCRIPTS_APP_BUILD_DIR = undefined
+    process.env.COZY_SCRIPTS_APP_MANIFEST = undefined
   })
 
   afterAll(() => {
@@ -206,6 +209,36 @@ describe('cozy-scripts (cs) CLI', () => {
       callCLI()
     }).not.toThrow()
     expect(process.env.HOT_RELOAD).toBe('true')
+  })
+
+  it('should handle src directory path providing with --src-dir option', () => {
+    // add cli arguments
+    const customPath = 'custom/app/src'
+    addCLIArgs('watch', '--src-dir', customPath)
+    expect(() => {
+      callCLI()
+    }).not.toThrow()
+    expect(process.env.COZY_SCRIPTS_APP_SRC_DIR).toBe(customPath)
+  })
+
+  it('should handle build directory path providing with --build-dir option', () => {
+    // add cli arguments
+    const customPath = 'custom/app/buildHere'
+    addCLIArgs('watch', '--build-dir', 'custom/app/buildHere')
+    expect(() => {
+      callCLI()
+    }).not.toThrow()
+    expect(process.env.COZY_SCRIPTS_APP_BUILD_DIR).toBe(customPath)
+  })
+
+  it('should handle manifest path providing with --manifest option', () => {
+    // add cli arguments
+    const customPath = 'custom/app/manifest.webapp'
+    addCLIArgs('watch', '--manifest', 'custom/app/manifest.webapp')
+    expect(() => {
+      callCLI()
+    }).not.toThrow()
+    expect(process.env.COZY_SCRIPTS_APP_MANIFEST).toBe(customPath)
   })
 
   it('should handle --production option', () => {

--- a/packages/cozy-scripts/utils/cleanBuild.js
+++ b/packages/cozy-scripts/utils/cleanBuild.js
@@ -5,9 +5,9 @@ const paths = require('./paths')
 
 module.exports = target => {
   if (target === 'mobile') {
-    fs.emptyDir(paths.appMobileWWW)
+    fs.emptyDir(paths.appMobileWWW())
   } else if (target === 'browser') {
-    fs.emptyDir(paths.appBuild)
+    fs.emptyDir(paths.appBuild())
   } else {
     console.warn(`No build folder found to clean (target ${target}).`)
   }

--- a/packages/cozy-scripts/utils/paths.js
+++ b/packages/cozy-scripts/utils/paths.js
@@ -3,58 +3,71 @@
 const path = require('path')
 const fs = require('fs')
 
-const appDirectory = fs.realpathSync(process.cwd())
-const resolveApp = relativePath => path.resolve(appDirectory, relativePath)
 const resolveOwn = relativePath => path.resolve(__dirname, '..', relativePath)
+const appDirectory = fs.realpathSync(process.cwd())
+const resolveApp = (relativePath = '.', fromDirectory = appDirectory) =>
+  path.resolve(fromDirectory, relativePath)
 
-// This must be used inside a function (called when needed)
+// Those must be used inside a function (called when needed)
 // to be sure to use the current process.env context
 // and not the one at the first loading of this file
-const resolveWithExtension = (path, extension) => {
-  const ext = extension || process.env.__ENTRY_EXT__ || '.js'
-  return resolveApp(`${path}${ext}`)
+const resolveAppSrc = (path = '.') => {
+  const appSrcDirectory = process.env.COZY_SCRIPTS_APP_SRC_DIR || 'src'
+  return resolveApp(path, resolveApp(appSrcDirectory))
 }
 
+const resolveWithExtension = (path, extension) => {
+  const ext = extension || process.env.__ENTRY_EXT__ || '.js'
+  return resolveAppSrc(`${path}${ext}`)
+}
+
+const resolveAppBuild = (path = '.') => {
+  const appBuildDirectory = process.env.COZY_SCRIPTS_APP_BUILD_DIR || 'build'
+  return resolveApp(path, resolveApp(appBuildDirectory))
+}
+
+const resolveAppManifest = () => {
+  const appManifest = process.env.COZY_SCRIPTS_APP_MANIFEST || 'manifest.webapp'
+  return resolveApp(appManifest)
+}
+
+// We use them as functions for all for more consistency
 module.exports = {
-  appPath: resolveApp('.'),
-  appBuild: resolveApp('build'),
-  appServicesBuild: resolveApp('build/services'),
-  appBuildAssetsJson: resolveApp('build/assets/json'),
-  appPackageJson: resolveApp('package.json'),
-  appManifest: resolveApp('manifest.webapp'),
-  appREADME: resolveApp('README.md'),
-  appLICENSE: resolveApp('LICENSE'),
-  appSrc: resolveApp('src'),
-  appLocales: resolveApp('src/locales'),
-  appVendorAssets: resolveApp('src/targets/vendor/assets'),
-  appNodeModules: resolveApp('node_modules'),
+  appPath: () => resolveApp(),
+  appBuild: () => resolveAppBuild(),
+  appServicesBuild: () => resolveAppBuild('services'),
+  appBuildAssetsJson: () => resolveAppBuild('assets/json'),
+  appManifest: () => resolveAppManifest(),
+  appREADME: () => resolveApp('README.md'),
+  appLICENSE: () => resolveApp('LICENSE'),
+  appSrc: () => resolveAppSrc(),
+  appLocales: () => resolveAppSrc('locales'),
+  appVendorAssets: () => resolveAppSrc('targets/vendor/assets'),
+  appNodeModules: () => resolveApp('node_modules'),
   // for browser
-  appBrowserHtmlTemplate: resolveApp('src/targets/browser/index.ejs'),
-  appBrowserIndex: ext =>
-    resolveWithExtension('src/targets/browser/index', ext),
+  appBrowserHtmlTemplate: () => resolveAppSrc('targets/browser/index.ejs'),
+  appBrowserIndex: ext => resolveWithExtension('targets/browser/index', ext),
   // for intents
-  appIntentsHtmlTemplate: resolveApp('src/targets/intents/index.ejs'),
-  appIntentsIndex: ext =>
-    resolveWithExtension('src/targets/intents/index', ext),
+  appIntentsHtmlTemplate: () => resolveAppSrc('targets/intents/index.ejs'),
+  appIntentsIndex: ext => resolveWithExtension('targets/intents/index', ext),
   // for services
-  appServicesFolder: resolveApp('src/targets/services'),
+  appServicesFolder: () => resolveAppSrc('targets/services'),
   // for mobile
-  appMobileHtmlTemplate: resolveApp('src/targets/mobile/index.ejs'),
-  appMobileIndex: ext => resolveWithExtension('src/targets/mobile/index', ext),
-  appMobileWWW: resolveApp('src/targets/mobile/www'),
+  appMobileHtmlTemplate: () => resolveAppSrc('targets/mobile/index.ejs'),
+  appMobileIndex: ext => resolveWithExtension('targets/mobile/index', ext),
+  appMobileWWW: () => resolveAppSrc('targets/mobile/www'),
   // for app local cozy-bar (dev only)
-  appCozyBarJs: resolveApp('node_modules/cozy-bar/dist/cozy-bar.js'),
-  appCozyBarCss: resolveApp('node_modules/cozy-bar/dist/cozy-bar.css'),
-  appCozyClientJs: resolveApp(
-    'node_modules/cozy-client-js/dist/cozy-client.js'
-  ),
+  appCozyBarJs: () => resolveApp('node_modules/cozy-bar/dist/cozy-bar.js'),
+  appCozyBarCss: () => resolveApp('node_modules/cozy-bar/dist/cozy-bar.css'),
+  appCozyClientJs: () =>
+    resolveApp('node_modules/cozy-client-js/dist/cozy-client.js'),
   // cozy-ui
-  appCozyUiStylus: resolveApp('node_modules/cozy-ui/stylus'),
+  appCozyUiStylus: () => resolveApp('node_modules/cozy-ui/stylus'),
 
   // for cozy-scripts
-  csDisableCSPConfig: resolveOwn('stack/disableCSP.yaml'),
-  csEslintBinary: resolveOwn('node_modules/.bin/eslint'),
-  csReactExposer: resolveOwn('utils/reactExposer.js'),
-  csPreactExposer: resolveOwn('utils/preactExposer.js'),
-  csQuitStackScript: resolveOwn('stack/quitStack.sh')
+  csDisableCSPConfig: () => resolveOwn('stack/disableCSP.yaml'),
+  csEslintBinary: () => resolveOwn('node_modules/.bin/eslint'),
+  csReactExposer: () => resolveOwn('utils/reactExposer.js'),
+  csPreactExposer: () => resolveOwn('utils/preactExposer.js'),
+  csQuitStackScript: () => resolveOwn('stack/quitStack.sh')
 }


### PR DESCRIPTION
* More robust paths file usage by using as functions
* Add CLI more options to provide custom application paths: `--src-dir`, `--build-dir`, `--manifest`