### PR TITLE
feat: Added loader for font files

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -56,6 +56,13 @@ module.exports = {
             }
           }
         ]
+      },
+      {
+        test: /\.(eot|ttf|woff|woff2)$/,
+        loader: require.resolve('file-loader'),
+        options: {
+          name: `[name].[ext]`
+        }
       }
     ],
     noParse: [/localforage\/dist/]

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -58,6 +58,13 @@ Array [
           ],
         },
         Object {
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app-vue/node_modules/vue-loader/lib/index.js",
           "test": Object {},
@@ -415,6 +422,13 @@ Array [
           ],
         },
         Object {
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app-vue/node_modules/vue-loader/lib/index.js",
           "test": Object {},
@@ -755,6 +769,13 @@ Array [
               },
             },
           ],
+        },
+        Object {
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
         },
         Object {
           "exclude": Object {},
@@ -1117,6 +1138,13 @@ Array [
           ],
         },
         Object {
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app-vue/node_modules/vue-loader/lib/index.js",
           "test": Object {},
@@ -1465,6 +1493,13 @@ Array [
               },
             },
           ],
+        },
+        Object {
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
         },
         Object {
           "exclude": Object {},
@@ -1823,6 +1858,13 @@ Array [
               },
             },
           ],
+        },
+        Object {
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
         },
         Object {
           "exclude": Object {},

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -117,6 +117,13 @@ Array [
           ],
         },
         Object {
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/babel-loader/lib/index.js",
           "options": Object {
@@ -517,6 +524,13 @@ Array [
           ],
         },
         Object {
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/babel-loader/lib/index.js",
           "options": Object {
@@ -900,6 +914,13 @@ Array [
               },
             },
           ],
+        },
+        Object {
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
         },
         Object {
           "exclude": Object {},
@@ -1305,6 +1326,13 @@ Array [
           ],
         },
         Object {
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/babel-loader/lib/index.js",
           "options": Object {
@@ -1696,6 +1724,13 @@ Array [
               },
             },
           ],
+        },
+        Object {
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
         },
         Object {
           "exclude": Object {},
@@ -2097,6 +2132,13 @@ Array [
               },
             },
           ],
+        },
+        Object {
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
         },
         Object {
           "exclude": Object {},
@@ -2562,6 +2604,13 @@ Array [
               },
             },
           ],
+        },
+        Object {
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+          },
+          "test": Object {},
         },
         Object {
           "exclude": Object {},


### PR DESCRIPTION
In mobile apps, we need to load the fonts along with the rest of the assets, but there's no loader configured for them at the moment.