### PR TITLE
feat: BREAKING CHANGE don't auto-inject mobile chunks (mobile target only)

### DIFF
--- a/packages/cozy-scripts/config/webpack.target.mobile.js
+++ b/packages/cozy-scripts/config/webpack.target.mobile.js
@@ -41,7 +41,7 @@ module.exports = {
       template: paths.appMobileHtmlTemplate(),
       title: appName,
       chunks: ['vendors', 'app'],
-      inject: 'head',
+      inject: false,
       minify: {
         collapseWhitespace: true
       }

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -1000,7 +1000,7 @@ Array [
           "favicon": false,
           "filename": "index.html",
           "hash": false,
-          "inject": "head",
+          "inject": false,
           "meta": Object {},
           "minify": Object {
             "collapseWhitespace": true,
@@ -1368,7 +1368,7 @@ Array [
           "favicon": false,
           "filename": "index.html",
           "hash": false,
-          "inject": "head",
+          "inject": false,
           "meta": Object {},
           "minify": Object {
             "collapseWhitespace": true,

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -1188,7 +1188,7 @@ Array [
           "favicon": false,
           "filename": "index.html",
           "hash": false,
-          "inject": "head",
+          "inject": false,
           "meta": Object {},
           "minify": Object {
             "collapseWhitespace": true,
@@ -1599,7 +1599,7 @@ Array [
           "favicon": false,
           "filename": "index.html",
           "hash": false,
-          "inject": "head",
+          "inject": false,
           "meta": Object {},
           "minify": Object {
             "collapseWhitespace": true,


### PR DESCRIPTION
This is more a suggestion, but every other `target` uses `inject: false` — so if you use the same template on mobile, things go very wrong. It's a breaking change but I think it makes things homogeneous and makes more sense.