### PR TITLE
Build intents and public chunks in specific folders

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.chunks.js
+++ b/packages/cozy-scripts/config/webpack.config.chunks.js
@@ -8,7 +8,9 @@ module.exports = {
         vendors: {
           test: /[\\/]node_modules[\\/]/,
           name: 'vendors',
-          chunks: 'all'
+          // exclude public chunk since public script must contains all
+          // modules itself
+          chunks: chunk => chunk.name !== 'public'
         }
       }
     }

--- a/packages/cozy-scripts/config/webpack.config.intents.js
+++ b/packages/cozy-scripts/config/webpack.config.intents.js
@@ -5,6 +5,8 @@ const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const manifest = fs.readJsonSync(paths.appManifest())
 
+const intentsFolderName = 'intents'
+
 const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
   : manifest.name
@@ -16,13 +18,16 @@ function getConfig() {
         entry: {
           // since the file extension depends on the framework here
           // we get it from a function call
-          intents: [require.resolve('babel-polyfill'), paths.appIntentsIndex()]
+          [intentsFolderName]: [
+            require.resolve('babel-polyfill'),
+            paths.appIntentsIndex()
+          ]
         },
         plugins: [
           new HtmlWebpackPlugin({
             template: paths.appIntentsHtmlTemplate(),
             title: `${appName} intents`,
-            filename: 'intents/index.html',
+            filename: `${intentsFolderName}/index.html`,
             inject: false,
             chunks: ['vendors', 'intents'],
             minify: {

--- a/packages/cozy-scripts/config/webpack.config.public.js
+++ b/packages/cozy-scripts/config/webpack.config.public.js
@@ -5,6 +5,8 @@ const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const manifest = fs.readJsonSync(paths.appManifest())
 
+const publicFolderName = 'public'
+
 const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
   : manifest.name
@@ -16,13 +18,16 @@ function getConfig() {
         entry: {
           // since the file extension depends on the framework here
           // we get it from a function call
-          public: [require.resolve('babel-polyfill'), paths.appPublicIndex()]
+          [publicFolderName]: [
+            require.resolve('babel-polyfill'),
+            paths.appPublicIndex()
+          ]
         },
         plugins: [
           new HtmlWebpackPlugin({
             template: paths.appPublicHtmlTemplate(),
             title: appName,
-            filename: 'public/index.html',
+            filename: `${publicFolderName}/index.html`,
             inject: false,
             chunks: ['vendors', 'public'],
             minify: {

--- a/packages/cozy-scripts/config/webpack.config.public.js
+++ b/packages/cozy-scripts/config/webpack.config.public.js
@@ -29,7 +29,7 @@ function getConfig() {
             title: appName,
             filename: `${publicFolderName}/index.html`,
             inject: false,
-            chunks: ['vendors', 'public'],
+            chunks: ['public'],
             minify: {
               collapseWhitespace: true
             }

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -34,8 +34,8 @@ const getCSSLoader = function() {
 
 const getFilename = function() {
   return environment === 'production'
-    ? `${manifest.slug}.[name].[contenthash]`
-    : `${manifest.slug}.[name]`
+    ? `[name]/${manifest.slug}.[contenthash]`
+    : `[name]/${manifest.slug}`
 }
 
 module.exports = {

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -165,7 +165,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -529,7 +528,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -879,7 +877,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -1247,7 +1244,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -1604,7 +1600,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -1969,7 +1964,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -173,15 +173,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app-vue.[name].js",
+      "filename": "[name]/test-app-vue.js",
       "path": ".tmp_test/test-app-vue/build",
       "pathinfo": false,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app-vue.[name].css",
-          "filename": "test-app-vue.[name].css",
+          "chunkFilename": "[name]/test-app-vue.css",
+          "filename": "[name]/test-app-vue.css",
         },
       },
       Object {
@@ -537,15 +537,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app-vue.[name].[contenthash].js",
+      "filename": "[name]/test-app-vue.[contenthash].js",
       "path": ".tmp_test/test-app-vue/build",
       "pathinfo": false,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app-vue.[name].[contenthash].[id].min.css",
-          "filename": "test-app-vue.[name].[contenthash].min.css",
+          "chunkFilename": "[name]/test-app-vue.[contenthash].[id].min.css",
+          "filename": "[name]/test-app-vue.[contenthash].min.css",
         },
       },
       Object {
@@ -893,8 +893,8 @@ Array [
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app-vue.[name].css",
-          "filename": "test-app-vue.[name].css",
+          "chunkFilename": "[name]/test-app-vue.css",
+          "filename": "[name]/test-app-vue.css",
         },
       },
       Object {
@@ -1261,8 +1261,8 @@ Array [
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app-vue.[name].[contenthash].[id].min.css",
-          "filename": "test-app-vue.[name].[contenthash].min.css",
+          "chunkFilename": "[name]/test-app-vue.[contenthash].[id].min.css",
+          "filename": "[name]/test-app-vue.[contenthash].min.css",
         },
       },
       Object {
@@ -1612,15 +1612,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app-vue.[name].js",
+      "filename": "[name]/test-app-vue.js",
       "path": ".tmp_test/test-app-vue/build",
       "pathinfo": false,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app-vue.[name].css",
-          "filename": "test-app-vue.[name].css",
+          "chunkFilename": "[name]/test-app-vue.css",
+          "filename": "[name]/test-app-vue.css",
         },
       },
       Object {
@@ -1977,15 +1977,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app-vue.[name].js",
+      "filename": "[name]/test-app-vue.js",
       "path": ".tmp_test/test-app-vue/build",
       "pathinfo": true,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app-vue.[name].css",
-          "filename": "test-app-vue.[name].css",
+          "chunkFilename": "[name]/test-app-vue.css",
+          "filename": "[name]/test-app-vue.css",
         },
       },
       Object {

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -261,7 +261,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -668,7 +667,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -1061,7 +1059,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -1472,7 +1469,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -1872,7 +1868,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -2280,7 +2275,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },
@@ -2753,7 +2747,6 @@ Array [
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
-            "chunks": "all",
             "name": "vendors",
             "test": Object {},
           },

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -269,15 +269,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app.[name].js",
+      "filename": "[name]/test-app.js",
       "path": ".tmp_test/test-app/build",
       "pathinfo": false,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app.[name].css",
-          "filename": "test-app.[name].css",
+          "chunkFilename": "[name]/test-app.css",
+          "filename": "[name]/test-app.css",
         },
       },
       Object {
@@ -676,15 +676,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app.[name].[contenthash].js",
+      "filename": "[name]/test-app.[contenthash].js",
       "path": ".tmp_test/test-app/build",
       "pathinfo": false,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app.[name].[contenthash].[id].min.css",
-          "filename": "test-app.[name].[contenthash].min.css",
+          "chunkFilename": "[name]/test-app.[contenthash].[id].min.css",
+          "filename": "[name]/test-app.[contenthash].min.css",
         },
       },
       Object {
@@ -1075,8 +1075,8 @@ Array [
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app.[name].css",
-          "filename": "test-app.[name].css",
+          "chunkFilename": "[name]/test-app.css",
+          "filename": "[name]/test-app.css",
         },
       },
       Object {
@@ -1486,8 +1486,8 @@ Array [
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app.[name].[contenthash].[id].min.css",
-          "filename": "test-app.[name].[contenthash].min.css",
+          "chunkFilename": "[name]/test-app.[contenthash].[id].min.css",
+          "filename": "[name]/test-app.[contenthash].min.css",
         },
       },
       Object {
@@ -1880,15 +1880,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app.[name].js",
+      "filename": "[name]/test-app.js",
       "path": ".tmp_test/test-app/build",
       "pathinfo": false,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app.[name].css",
-          "filename": "test-app.[name].css",
+          "chunkFilename": "[name]/test-app.css",
+          "filename": "[name]/test-app.css",
         },
       },
       Object {
@@ -2288,15 +2288,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app.[name].js",
+      "filename": "[name]/test-app.js",
       "path": ".tmp_test/test-app/build",
       "pathinfo": true,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app.[name].css",
-          "filename": "test-app.[name].css",
+          "chunkFilename": "[name]/test-app.css",
+          "filename": "[name]/test-app.css",
         },
       },
       Object {
@@ -2761,15 +2761,15 @@ Array [
       },
     },
     "output": Object {
-      "filename": "test-app.[name].js",
+      "filename": "[name]/test-app.js",
       "path": ".tmp_test/test-app/build",
       "pathinfo": false,
     },
     "plugins": Array [
       Object {
         "options": Object {
-          "chunkFilename": "test-app.[name].css",
-          "filename": "test-app.[name].css",
+          "chunkFilename": "[name]/test-app.css",
+          "filename": "[name]/test-app.css",
         },
       },
       Object {
@@ -3003,7 +3003,7 @@ Array [
     },
     "optimization": Object {},
     "output": Object {
-      "filename": "test-app.[name].js",
+      "filename": "[name]/test-app.js",
       "path": ".tmp_test/test-app/build/services",
     },
     "plugins": Array [


### PR DESCRIPTION
* Build all app files into `build/app`
* Build all vendors files into `build/vendors`
* Build all intents files into `build/intents`
* Build all public files into `build/public`

Since the `.html` files don't change place, this concerns only paths computed by Webpack so this is not a breaking change.
Need context: The cozy-stack need to have all files in the `public/` folder to server public (not authenticated) pages