### PR TITLE
Better handling public assets

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.pictures.js
+++ b/packages/cozy-scripts/config/webpack.config.pictures.js
@@ -1,8 +1,7 @@
 'use strict'
-const { environment, target } = require('./webpack.vars')
+const { environment } = require('./webpack.vars')
 const SpriteLoaderPlugin = require('svg-sprite-loader/plugin')
 
-const isMobileApp = target === 'mobile'
 module.exports = {
   module: {
     rules: [
@@ -16,11 +15,25 @@ module.exports = {
       },
       {
         test: /\.(png|gif|jpe?g|svg)$/i,
-        exclude: /(sprites|icons)/,
+        exclude: /(sprites|icons|public)/,
         loader: require.resolve('file-loader'),
         options: {
-          outputPath: isMobileApp ? './img' : 'img/',
-          publicPath: isMobileApp ? './img' : '/img',
+          outputPath: './img',
+          publicPath: './img',
+          name: `[name]${environment === 'production' ? '.[hash]' : ''}.[ext]`
+        }
+      },
+      /*
+        For public pages, we need to have all used assets into the build/public
+        folder in order to be served by cozy-stack in the public pages
+      */
+      {
+        test: /\.(png|gif|jpe?g|svg)$/i,
+        include: /public/,
+        loader: require.resolve('file-loader'),
+        options: {
+          outputPath: './public/img',
+          publicPath: './public/img',
           name: `[name]${environment === 'production' ? '.[hash]' : ''}.[ext]`
         }
       }

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -149,8 +149,18 @@ Array [
           "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -513,8 +523,18 @@ Array [
           "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[hash].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -865,6 +885,16 @@ Array [
             "name": "[name].[ext]",
             "outputPath": "./img",
             "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -1237,6 +1267,16 @@ Array [
           "test": Object {},
         },
         Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[hash].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/json-loader/index.js",
           "test": Object {},
@@ -1588,8 +1628,18 @@ Array [
           "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -1953,8 +2003,18 @@ Array [
           "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -245,8 +245,18 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -652,8 +662,18 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[hash].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -1047,6 +1067,16 @@ Array [
             "name": "[name].[ext]",
             "outputPath": "./img",
             "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -1462,6 +1492,16 @@ Array [
           "test": Object {},
         },
         Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[hash].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
+          },
+          "test": Object {},
+        },
+        Object {
           "exclude": Object {},
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/json-loader/index.js",
           "test": Object {},
@@ -1856,8 +1896,18 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -2264,8 +2314,18 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },
@@ -2737,8 +2797,18 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "img/",
-            "publicPath": "/img",
+            "outputPath": "./img",
+            "publicPath": "./img",
+          },
+          "test": Object {},
+        },
+        Object {
+          "include": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
+          "options": Object {
+            "name": "[name].[ext]",
+            "outputPath": "./public/img",
+            "publicPath": "./public/img",
           },
           "test": Object {},
         },


### PR DESCRIPTION
All resources used by the public pages must be in a public folder or subfolder in order to be put correctly in `build/public` in order to be hanlde as public by the stack