### PR TITLE
feat(cozy-scripts): Handle flags at build time

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.base.js
+++ b/packages/cozy-scripts/config/webpack.config.base.js
@@ -9,7 +9,8 @@ const {
   environment,
   isDebugMode,
   getCSSLoader,
-  getFilename
+  getFilename,
+  getEnabledFlags
 } = require('./webpack.vars')
 const production = environment === 'production'
 
@@ -91,6 +92,9 @@ module.exports = {
       )
     }),
     // use a hash as chunk id to avoid id changes of not changing chunk
-    new webpack.HashedModuleIdsPlugin()
+    new webpack.HashedModuleIdsPlugin(),
+    new webpack.DefinePlugin({
+      __ENABLED_FLAGS__: JSON.stringify(getEnabledFlags())
+    })
   ]
 }

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -39,10 +39,19 @@ const getFilename = function(enableProductionHash = true) {
     : `[name]/${manifest.slug}`
 }
 
+const getEnabledFlags = function() {
+  if (typeof process.env.COZY_FLAGS !== 'string') {
+    return []
+  }
+
+  return process.env.COZY_FLAGS.split(',')
+}
+
 module.exports = {
   addAnalyzer,
   environment,
   eslintFix,
+  getEnabledFlags,
   getFilename,
   getCSSLoader,
   isDebugMode,

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -269,7 +269,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,
@@ -642,7 +648,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,
@@ -998,7 +1010,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": true,
@@ -1375,7 +1393,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": false,
@@ -1740,7 +1764,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,
@@ -2113,7 +2143,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -209,6 +209,11 @@ Array [
           "hashFunction": "md4",
         },
       },
+      Object {
+        "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
       Object {},
       Object {
         "config": Object {
@@ -264,13 +269,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,
@@ -583,6 +582,11 @@ Array [
           "hashFunction": "md4",
         },
       },
+      Object {
+        "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
       Object {},
       Object {
         "config": Object {
@@ -638,13 +642,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,
@@ -940,6 +938,11 @@ Array [
           "hashFunction": "md4",
         },
       },
+      Object {
+        "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
       Object {},
       Object {
         "config": Object {
@@ -995,13 +998,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": true,
@@ -1318,6 +1315,11 @@ Array [
           "hashFunction": "md4",
         },
       },
+      Object {
+        "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
       Object {},
       Object {
         "config": Object {
@@ -1373,13 +1375,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": false,
@@ -1684,6 +1680,11 @@ Array [
           "hashFunction": "md4",
         },
       },
+      Object {
+        "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
       Object {},
       Object {
         "config": Object {
@@ -1739,13 +1740,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,
@@ -2058,6 +2053,11 @@ Array [
           "hashFunction": "md4",
         },
       },
+      Object {
+        "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
       Object {},
       Object {
         "config": Object {
@@ -2113,13 +2113,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -371,7 +371,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,
@@ -787,7 +793,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,
@@ -1186,7 +1198,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": true,
@@ -1606,7 +1624,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": false,
@@ -2014,7 +2038,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,
@@ -2430,7 +2460,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,
@@ -2911,7 +2947,13 @@ Array [
       },
       Object {},
       Object {},
-      Object {},
+      Object {
+        "modulesCount": 500,
+        "profile": false,
+        "showActiveModules": true,
+        "showEntries": false,
+        "showModules": true,
+      },
       Object {
         "options": Object {
           "cache": true,

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -307,6 +307,11 @@ Array [
       },
       Object {
         "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
+      Object {
+        "definitions": Object {
           "process.env": Object {
             "USE_REACT": "true",
           },
@@ -366,13 +371,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,
@@ -724,6 +723,11 @@ Array [
       },
       Object {
         "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
+      Object {
+        "definitions": Object {
           "process.env": Object {
             "USE_REACT": "true",
           },
@@ -783,13 +787,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,
@@ -1124,6 +1122,11 @@ Array [
       },
       Object {
         "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
+      Object {
+        "definitions": Object {
           "process.env": Object {
             "USE_REACT": "true",
           },
@@ -1183,13 +1186,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": true,
@@ -1545,6 +1542,11 @@ Array [
       },
       Object {
         "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
+      Object {
+        "definitions": Object {
           "process.env": Object {
             "USE_REACT": "true",
           },
@@ -1604,13 +1606,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "definitions": Object {
           "__ALLOW_HTTP__": false,
@@ -1954,6 +1950,11 @@ Array [
       },
       Object {
         "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
+      Object {
+        "definitions": Object {
           "process.env": Object {
             "USE_REACT": "true",
           },
@@ -2013,13 +2014,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,
@@ -2371,6 +2366,11 @@ Array [
       },
       Object {
         "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
+      Object {
+        "definitions": Object {
           "process.env": Object {
             "USE_REACT": "true",
           },
@@ -2430,13 +2430,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,
@@ -2853,6 +2847,11 @@ Array [
       },
       Object {
         "definitions": Object {
+          "__ENABLED_FLAGS__": "[]",
+        },
+      },
+      Object {
+        "definitions": Object {
           "process.env": Object {
             "USE_REACT": "true",
           },
@@ -2912,13 +2911,7 @@ Array [
       },
       Object {},
       Object {},
-      Object {
-        "modulesCount": 500,
-        "profile": false,
-        "showActiveModules": true,
-        "showEntries": false,
-        "showModules": true,
-      },
+      Object {},
       Object {
         "options": Object {
           "cache": true,


### PR DESCRIPTION
Following what we did in banks (see https://github.com/cozy/cozy-banks/pull/703).

This enables us to provide some flags that should be enabled when we build an app. For example: `COZY_FLAGS=balance-panels yarn build`.

This is useful when we want to make a build to validate a feature that is behind a flag, for example. It pairs nicely with `deploy2cozy`: `COZY_FLAGS=balance-panels deploy2cozy` will build the app with `balance-panels` flag turned on and deploy it to a temporary instance. The feature, even if behind a flag, can now be easily validated. Same goes for mobile apps.