### PR TITLE
feat(cozy-scripts): Show regexp when using --show-config flag

### DIFF
--- a/packages/cozy-scripts/bin/cozy-scripts.js
+++ b/packages/cozy-scripts/bin/cozy-scripts.js
@@ -6,6 +6,7 @@ const commander = require('commander')
 const pkg = require('../package.json')
 const colorize = require('../utils/_colorize.js')
 const CTS = require('../utils/constants.js')
+const regexpReplacer = require('../utils/regexpReplacer')
 const getWebpackConfigs = require('../scripts/config')
 
 let actionName
@@ -86,7 +87,7 @@ const options = {
 })
 
 if (program.showConfig) {
-  console.log(JSON.stringify(getWebpackConfigs(options), null, 2))
+  console.log(JSON.stringify(getWebpackConfigs(options), regexpReplacer, 2))
 } else {
   const availableScripts = [
     'build',

--- a/packages/cozy-scripts/utils/regexpReplacer.js
+++ b/packages/cozy-scripts/utils/regexpReplacer.js
@@ -1,0 +1,7 @@
+module.exports = function regexpReplacer(key, value) {
+  if (value instanceof RegExp) {
+    return value.toString()
+  }
+
+  return value
+}


### PR DESCRIPTION
When using `--show-config`, `module.rules.test` were shown as empty object (`{}`). This is due to how `JSON.stringify` treats regexp objects. I added a replacer function that calls `toString` on regexp during stringify process. So now when we have `test: /\.css$/`, `--show-config` outputs `"test": "/\\.css$/"`.