### PR TITLE
Don't use hash for services files name

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.services.js
+++ b/packages/cozy-scripts/config/webpack.config.services.js
@@ -30,7 +30,7 @@ const config = {
   entry: servicesEntries,
   output: {
     path: paths.appServicesBuild(),
-    filename: `${getFilename()}.js`
+    filename: `${getFilename(false)}.js`
   },
   target: 'node',
   optimization: {}, // reset optimization property

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -32,8 +32,8 @@ const getCSSLoader = function() {
     : MiniCssExtractPlugin.loader
 }
 
-const getFilename = function() {
-  return environment === 'production'
+const getFilename = function(enableProductionHash = true) {
+  return environment === 'production' && enableProductionHash
     ? `[name]/${manifest.slug}.[contenthash]`
     : `[name]/${manifest.slug}`
 }


### PR DESCRIPTION
Since we need to specify services files name into the manifest we can't have a dynamic hash into the name.