### PR TITLE
Remove externals property for services build

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.services.js
+++ b/packages/cozy-scripts/config/webpack.config.services.js
@@ -24,7 +24,8 @@ const config = {
       output: 'replace',
       entry: 'replace',
       optimization: 'replace',
-      module: 'replace'
+      module: 'replace',
+      externals: 'replace'
     }
   },
   entry: servicesEntries,
@@ -35,6 +36,7 @@ const config = {
   target: 'node',
   optimization: {}, // reset optimization property
   devtool: false,
+  externals: [], // reset externals property
   module: {
     rules: [
       {

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -3025,9 +3025,7 @@ Array [
     "entry": Object {
       "testservice": ".tmp_test/test-app/src/targets/services/testservice.js",
     },
-    "externals": Array [
-      "cozy",
-    ],
+    "externals": Array [],
     "mode": "development",
     "module": Object {
       "rules": Array [


### PR DESCRIPTION
Externals was making webpack not including all dependencies into services builds.