### PR TITLE
Handle services by default + build public/intents only for browser target

### DIFF
--- a/packages/cozy-scripts/config/webpack.bundle.default.js
+++ b/packages/cozy-scripts/config/webpack.bundle.default.js
@@ -17,6 +17,7 @@ const configs = [
   require('./webpack.config.manifest'),
   require('./webpack.config.progress'),
   addAnalyzer ? require('./webpack.config.analyzer') : null,
+  require('./webpack.config.services'),
   require(`./webpack.target.${target}`)
 ]
 

--- a/packages/cozy-scripts/config/webpack.bundle.preact.js
+++ b/packages/cozy-scripts/config/webpack.bundle.preact.js
@@ -17,6 +17,7 @@ const configs = [
   require('./webpack.config.manifest'),
   require('./webpack.config.progress'),
   addAnalyzer ? require('./webpack.config.analyzer') : null,
+  require('./webpack.config.services'),
   require(`./webpack.target.${target}`)
 ]
 

--- a/packages/cozy-scripts/config/webpack.bundle.vue.js
+++ b/packages/cozy-scripts/config/webpack.bundle.vue.js
@@ -16,6 +16,7 @@ const configs = [
   require('./webpack.config.manifest'),
   require('./webpack.config.progress'),
   addAnalyzer ? require('./webpack.config.analyzer') : null,
+  require('./webpack.config.services'),
   require(`./webpack.target.${target}`)
 ]
 

--- a/packages/cozy-scripts/config/webpack.config.intents.js
+++ b/packages/cozy-scripts/config/webpack.config.intents.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const manifest = fs.readJsonSync(paths.appManifest())
+const { target } = require('./webpack.vars')
 
 const intentsFolderName = 'intents'
 
@@ -11,9 +12,14 @@ const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
   : manifest.name
 
+/* We don't build intents if no intents and if on mobile build */
+const addIntentsConfig =
+  target === 'browser' &&
+  fs.existsSync(paths.appIntentsIndex()) &&
+  fs.existsSync(paths.appIntentsHtmlTemplate())
+
 function getConfig() {
-  return fs.existsSync(paths.appIntentsIndex()) &&
-    fs.existsSync(paths.appIntentsHtmlTemplate())
+  return addIntentsConfig
     ? {
         entry: {
           // since the file extension depends on the framework here

--- a/packages/cozy-scripts/config/webpack.config.public.js
+++ b/packages/cozy-scripts/config/webpack.config.public.js
@@ -4,15 +4,20 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const manifest = fs.readJsonSync(paths.appManifest())
-const { publicFolderName } = require('./webpack.vars')
+const { publicFolderName, target } = require('./webpack.vars')
 
 const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
   : manifest.name
 
+/* We don't build public if no public and if on mobile build */
+const addPublicConfig =
+  target === 'browser' &&
+  fs.existsSync(paths.appPublicIndex()) &&
+  fs.existsSync(paths.appPublicHtmlTemplate())
+
 function getConfig() {
-  return fs.existsSync(paths.appPublicIndex()) &&
-    fs.existsSync(paths.appPublicHtmlTemplate())
+  return addPublicConfig
     ? {
         entry: {
           // since the file extension depends on the framework here

--- a/packages/cozy-scripts/config/webpack.config.services.js
+++ b/packages/cozy-scripts/config/webpack.config.services.js
@@ -7,7 +7,9 @@ const paths = require('../utils/paths')
 const { eslintFix, getFilename, target } = require('./webpack.vars')
 
 const servicesFolder = paths.appServicesFolder()
-const servicesPaths = fs.readdirSync(servicesFolder)
+const servicesPaths = fs.existsSync(servicesFolder)
+  ? fs.readdirSync(servicesFolder)
+  : []
 
 const servicesEntries = {}
 servicesPaths.forEach(file => {
@@ -69,5 +71,9 @@ const config = {
   ]
 }
 
+/* We don't build services if no services and if on mobile build */
+const addServicesConfig =
+  target === 'browser' && Object.keys(servicesEntries).length
+
 // only for browser target (services are usable only on cozy-stack)
-module.exports = target === 'browser' ? { multiple: { services: config } } : {}
+module.exports = addServicesConfig ? { multiple: { services: config } } : {}

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -3060,6 +3060,37 @@ Array [
           },
           "test": Object {},
         },
+        Object {
+          "enforce": "pre",
+          "exclude": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/eslint-loader/index.js",
+          "options": Object {
+            "emitWarning": true,
+            "extends": Array [
+              "cozy-app",
+            ],
+            "fix": false,
+          },
+          "test": Object {},
+        },
+        Object {
+          "exclude": Object {},
+          "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/babel-loader/lib/index.js",
+          "options": Object {
+            "babelrc": false,
+            "cacheDirectory": "node_modules/.cache/babel-loader/node",
+            "presets": Array [
+              Array [
+                "cozy-app",
+                Object {
+                  "node": true,
+                  "react": false,
+                },
+              ],
+            ],
+          },
+          "test": Object {},
+        },
       ],
     },
     "optimization": Object {},
@@ -3068,6 +3099,11 @@ Array [
       "path": ".tmp_test/test-app/build/services",
     },
     "plugins": Array [
+      Object {
+        "definitions": Object {
+          "__TARGET__": "\\"services\\"",
+        },
+      },
       Object {
         "definitions": Object {
           "__TARGET__": "\\"services\\"",


### PR DESCRIPTION
* Add services config by default to bundles (if services files detected, it will be handled)
* Build intents and public entries only if target `browser`