### PR TITLE
fix(public/intent): React / Preact config

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.intents.js
+++ b/packages/cozy-scripts/config/webpack.config.intents.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const manifest = fs.readJsonSync(paths.appManifest())
-const { target } = require('./webpack.vars')
+const { target, getReactExposer } = require('./webpack.vars')
 
 const intentsFolderName = 'intents'
 
@@ -26,6 +26,8 @@ function getConfig() {
           // we get it from a function call
           [intentsFolderName]: [
             require.resolve('babel-polyfill'),
+            // Exposed variables in global scope (needed for cozy-bar)
+            getReactExposer(),
             paths.appIntentsIndex()
           ]
         },

--- a/packages/cozy-scripts/config/webpack.config.public.js
+++ b/packages/cozy-scripts/config/webpack.config.public.js
@@ -4,7 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const manifest = fs.readJsonSync(paths.appManifest())
-const { publicFolderName, target } = require('./webpack.vars')
+const { publicFolderName, target, getReactExposer } = require('./webpack.vars')
 
 const appName = manifest.name_prefix
   ? `${manifest.name_prefix} ${manifest.name}`
@@ -24,6 +24,8 @@ function getConfig() {
           // we get it from a function call
           [publicFolderName]: [
             require.resolve('babel-polyfill'),
+            // Exposed variables in global scope (needed for cozy-bar)
+            getReactExposer(),
             paths.appPublicIndex()
           ]
         },

--- a/packages/cozy-scripts/config/webpack.target.browser.js
+++ b/packages/cozy-scripts/config/webpack.target.browser.js
@@ -3,10 +3,9 @@
 const fs = require('fs-extra')
 const webpack = require('webpack')
 const paths = require('../utils/paths')
-const CTS = require('../utils/constants.js')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
-const { getFilename, isDebugMode } = require('./webpack.vars')
+const { getFilename, isDebugMode, getReactExposer } = require('./webpack.vars')
 const manifest = fs.readJsonSync(paths.appManifest())
 
 const appName = manifest.name_prefix
@@ -19,9 +18,7 @@ module.exports = {
       // polyfills, avaid to import it in the application
       require.resolve('babel-polyfill'),
       // Exposed variables in global scope (needed for cozy-bar)
-      process.env[CTS.USE_PREACT]
-        ? paths.csPreactExposer()
-        : paths.csReactExposer(),
+      getReactExposer(),
       // since the file extension depends on the framework here
       // we get it from a function call
       paths.appBrowserIndex()

--- a/packages/cozy-scripts/config/webpack.target.mobile.js
+++ b/packages/cozy-scripts/config/webpack.target.mobile.js
@@ -2,12 +2,11 @@
 
 const fs = require('fs-extra')
 const paths = require('../utils/paths')
-const CTS = require('../utils/constants.js')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 
-const { environment, isDebugMode } = require('./webpack.vars')
+const { environment, isDebugMode, getReactExposer } = require('./webpack.vars')
 const manifest = fs.readJsonSync(paths.appManifest())
 
 const production = environment === 'production'
@@ -22,9 +21,7 @@ module.exports = {
     app: [
       require.resolve('babel-polyfill'),
       // Exposed variables in global scope (needed for cozy-bar)
-      process.env[CTS.USE_PREACT]
-        ? paths.csPreactExposer()
-        : paths.csReactExposer(),
+      getReactExposer(),
       paths.appMobileIndex()
     ]
   },

--- a/packages/cozy-scripts/config/webpack.vars.js
+++ b/packages/cozy-scripts/config/webpack.vars.js
@@ -47,6 +47,12 @@ const getEnabledFlags = function() {
   return process.env.COZY_FLAGS.split(',')
 }
 
+const getReactExposer = function() {
+  return process.env[CTS.USE_PREACT]
+    ? paths.csPreactExposer()
+    : paths.csReactExposer()
+}
+
 module.exports = {
   addAnalyzer,
   environment,
@@ -57,5 +63,6 @@ module.exports = {
   isDebugMode,
   target,
   useHotReload,
-  publicFolderName
+  publicFolderName,
+  getReactExposer
 }


### PR DESCRIPTION
We expose React or Preact on Public and Intent page. 

But if you can explain to me why we need to add that stuff here since it's already in browser.config.js and since we already defined : `process.env[CTS.USE_PREACT] = true` in the preact.conf. 