### PR TITLE
Don't use absolute outputPath for file-loader

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.pictures.js
+++ b/packages/cozy-scripts/config/webpack.config.pictures.js
@@ -21,7 +21,7 @@ module.exports = {
         loader: require.resolve('file-loader'),
         options: {
           // mobile app needs relative path since it uses file://
-          outputPath: isMobile ? './img' : '/img',
+          outputPath: isMobile ? './img' : 'img/',
           publicPath: isMobile ? './img' : '/img',
           name: `[name]${environment === 'production' ? '.[hash]' : ''}.[ext]`
         }
@@ -36,7 +36,7 @@ module.exports = {
         loader: require.resolve('file-loader'),
         options: {
           // mobile app needs relative path since it uses file://
-          outputPath: isMobile ? './public/img' : '/public/img',
+          outputPath: isMobile ? './public/img' : 'public/img',
           publicPath: isMobile ? './public/img' : '/public/img',
           name: `[name]${environment === 'production' ? '.[hash]' : ''}.[ext]`
         }

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -245,7 +245,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/img",
+            "outputPath": "img/",
             "publicPath": "/img",
           },
           "test": Object {},
@@ -255,7 +255,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/public/img",
+            "outputPath": "public/img",
             "publicPath": "/public/img",
           },
           "test": Object {},
@@ -666,7 +666,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "/img",
+            "outputPath": "img/",
             "publicPath": "/img",
           },
           "test": Object {},
@@ -676,7 +676,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[hash].[ext]",
-            "outputPath": "/public/img",
+            "outputPath": "public/img",
             "publicPath": "/public/img",
           },
           "test": Object {},
@@ -1912,7 +1912,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/img",
+            "outputPath": "img/",
             "publicPath": "/img",
           },
           "test": Object {},
@@ -1922,7 +1922,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/public/img",
+            "outputPath": "public/img",
             "publicPath": "/public/img",
           },
           "test": Object {},
@@ -2334,7 +2334,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/img",
+            "outputPath": "img/",
             "publicPath": "/img",
           },
           "test": Object {},
@@ -2344,7 +2344,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/public/img",
+            "outputPath": "public/img",
             "publicPath": "/public/img",
           },
           "test": Object {},
@@ -2821,7 +2821,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/img",
+            "outputPath": "img/",
             "publicPath": "/img",
           },
           "test": Object {},
@@ -2831,7 +2831,7 @@ Array [
           "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/file-loader/dist/cjs.js",
           "options": Object {
             "name": "[name].[ext]",
-            "outputPath": "/public/img",
+            "outputPath": "public/img",
             "publicPath": "/public/img",
           },
           "test": Object {},


### PR DESCRIPTION
We should not use absolute path for outputPath since it will try to make directory in root.
Fix #1072 