### PR TITLE
fix: :fire: Avoid the glitch while loading the app

### DIFF
--- a/packages/cozy-scripts-vanilla/template/index.html
+++ b/packages/cozy-scripts-vanilla/template/index.html
@@ -4,14 +4,13 @@
   <meta charset="utf-8"/>
   <title><APP_NAME></title>
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
-  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32"/>
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16"/>
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#297EF2"/>
   <meta name="theme-color" content="#ffffff"/>
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover"/>
   <link rel="stylesheet" href="./styles/index.css"/>
-  <script src="./scripts/init.js" defer></script>
+  {{.ThemeCSS}}
   {{.CozyClientJS}}
   {{.CozyBar}}
 </head>
@@ -58,3 +57,4 @@
     </main>
   </div>
 </div>
+<script src="./scripts/init.js"></script>

--- a/packages/cozy-scripts-vanilla/template/view2.html
+++ b/packages/cozy-scripts-vanilla/template/view2.html
@@ -4,14 +4,13 @@
   <meta charset="utf-8"/>
   <title><APP_NAME></title>
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
-  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32"/>
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16"/>
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#297EF2"/>
   <meta name="theme-color" content="#ffffff"/>
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover"/>
   <link rel="stylesheet" href="./styles/index.css"/>
-  <script src="./scripts/init.js" defer></script>
+  {{.ThemeCSS}}
   {{.CozyClientJS}}
   {{.CozyBar}}
 </head>
@@ -58,3 +57,4 @@
     </main>
   </div>
 </div>
+<script src="./scripts/init.js"></script>

--- a/packages/cozy-scripts/template-vue/app/src/targets/browser/index.ejs
+++ b/packages/cozy-scripts/template-vue/app/src/targets/browser/index.ejs
@@ -4,15 +4,10 @@
   <meta charset="utf-8">
   <title><%= htmlWebpackPlugin.options.title %></title>
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover">
-  <% if (__TARGET__ !== 'mobile') { %>
-  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
-  <% } %>
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
       <link rel="stylesheet" href="<%- file %>">
   <% }); %>
-  <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
-      <script src="<%- file %>" defer></script>
-  <% }); %>
+  {{.ThemeCSS}}
   <% if (__TARGET__ === 'mobile') { %>
   <meta name="format-detection" content="telephone=no">
   <script src="cordova.js" defer></script>
@@ -32,3 +27,6 @@
   data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-icon-path="{{.IconPath}}"
 >
+<% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+    <script src="<%- file %>"></script>
+<% }); %>

--- a/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
+++ b/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
@@ -4,15 +4,10 @@
   <meta charset="utf-8">
   <title><%= htmlWebpackPlugin.options.title %></title>
   <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, viewport-fit=cover">
-  <% if (__TARGET__ !== 'mobile') { %>
-  <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
-  <% } %>
   <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
       <link rel="stylesheet" href="<%- file %>">
   <% }); %>
-  <% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
-      <script src="<%- file %>" defer></script>
-  <% }); %>
+  {{.ThemeCSS}}
   <% if (__TARGET__ === 'mobile') { %>
   <meta name="format-detection" content="telephone=no">
   <script src="cordova.js" defer></script>
@@ -31,3 +26,6 @@
   data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-icon-path="{{.IconPath}}"
 >
+<% _.forEach(htmlWebpackPlugin.files.js, function(file) { %>
+    <script src="<%- file %>"></script>
+<% }); %>


### PR DESCRIPTION
The users may have a flash of unstyled content without this fix: browsers don't wait that the CSSOM is ready to execute <script> with the defer attribute. It means that they can render before the CSS have been parser, and SVG icons are often rendered on the full screen in that case.