### PR TITLE
fix: :wrench: Do not use defer for scripts

### DIFF
--- a/packages/cozy-scripts/config/webpack.target.browser.js
+++ b/packages/cozy-scripts/config/webpack.target.browser.js
@@ -4,7 +4,6 @@ const fs = require('fs-extra')
 const webpack = require('webpack')
 const paths = require('../utils/paths')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 const { getFilename, isDebugMode, getReactExposer } = require('./webpack.vars')
 const manifest = fs.readJsonSync(paths.appManifest())
 
@@ -41,9 +40,6 @@ module.exports = {
       minify: {
         collapseWhitespace: true
       }
-    }),
-    new ScriptExtHtmlWebpackPlugin({
-      defaultAttribute: 'defer'
     }),
     new webpack.DefinePlugin({
       __TARGET__: JSON.stringify('browser')

--- a/packages/cozy-scripts/config/webpack.target.mobile.js
+++ b/packages/cozy-scripts/config/webpack.target.mobile.js
@@ -4,7 +4,6 @@ const fs = require('fs-extra')
 const paths = require('../utils/paths')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
-const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 
 const { environment, isDebugMode, getReactExposer } = require('./webpack.vars')
 const manifest = fs.readJsonSync(paths.appManifest())
@@ -51,9 +50,6 @@ module.exports = {
       minify: {
         collapseWhitespace: true
       }
-    }),
-    new ScriptExtHtmlWebpackPlugin({
-      defaultAttribute: 'defer'
     })
   ]
 }

--- a/packages/cozy-scripts/docs/webpack-configs.md
+++ b/packages/cozy-scripts/docs/webpack-configs.md
@@ -381,7 +381,6 @@ In this production mode, webpack will automatically use the `UglifyJs` plugin to
 - `externals` with `{ 'cozy-client-js': 'cozy' }` to exclude `cozy-client-js` (via `cozy.*`) dependency from the output bundle
 
 ##### Plugins:
-- `script-ext-html-webpack-plugin` to load the main application `.js` file using the `defer` attribute (to be loaded after the initial loading) and used with `html-webpack-plugin`
 - `html-webpack-plugin` configured to use `index.ejs` HTML template from `src/targets/browser/` with options:
     - `title`: `name` property of the `package.json`
     - `inject` to `false`
@@ -397,11 +396,9 @@ In this production mode, webpack will automatically use the `UglifyJs` plugin to
 - `output`: `src/targets/mobile/www` path and `pathinfo` enabling only with the `COZY_SCRIPTS_DEBUG` mode
 
 ##### Plugins:
-- `script-ext-html-webpack-plugin` to load the main application `.js` file using the `defer` attribute (to be loaded after the initial loading) and used with `html-webpack-plugin`
 - `html-webpack-plugin` configured to use `index.ejs` HTML template from `src/targets/mobile/` with options:
     - `title`: `name` property of the `package.json`
     - `excludeChunks`: to exclude chunk `intents`
-    - `inject` to `head`
     - `minify` with `collapseWhitespace` to `true`
 - `webpack.DefinePlugin` to define globals variables at compile time:
     - `__ALLOW_HTTP__` to `false` if `production` environment, `true` for other environments

--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -48,7 +48,6 @@
     "prompt": "1.0.0",
     "react": "16.8.2",
     "react-dom": "16.8.2",
-    "script-ext-html-webpack-plugin": "2.1.3",
     "style-loader": "0.23.1",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.2",

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -324,36 +324,6 @@ Array [
         },
       },
       Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
-        },
-      },
-      Object {
         "definitions": Object {
           "__TARGET__": "\\"browser\\"",
         },
@@ -726,36 +696,6 @@ Array [
         },
       },
       Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
-        },
-      },
-      Object {
         "definitions": Object {
           "__TARGET__": "\\"browser\\"",
         },
@@ -1121,36 +1061,6 @@ Array [
           "template": ".tmp_test/test-app-vue/src/targets/mobile/index.ejs",
           "title": "test-app-vue",
           "xhtml": false,
-        },
-      },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
         },
       },
       Object {
@@ -1529,36 +1439,6 @@ Array [
           "xhtml": false,
         },
       },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
-        },
-      },
       Object {},
       Object {
         "definitions": Object {
@@ -1908,36 +1788,6 @@ Array [
           "template": ".tmp_test/test-app-vue/src/targets/browser/index.ejs",
           "title": "test-app-vue",
           "xhtml": false,
-        },
-      },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
         },
       },
       Object {
@@ -2310,36 +2160,6 @@ Array [
           "template": ".tmp_test/test-app-vue/src/targets/browser/index.ejs",
           "title": "test-app-vue",
           "xhtml": false,
-        },
-      },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
         },
       },
       Object {

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -396,36 +396,6 @@ Array [
         },
       },
       Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
-        },
-      },
-      Object {
         "definitions": Object {
           "__TARGET__": "\\"browser\\"",
         },
@@ -814,36 +784,6 @@ Array [
         },
       },
       Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
-        },
-      },
-      Object {
         "definitions": Object {
           "__TARGET__": "\\"browser\\"",
         },
@@ -1225,36 +1165,6 @@ Array [
           "template": ".tmp_test/test-app/src/targets/mobile/index.ejs",
           "title": "test-app",
           "xhtml": false,
-        },
-      },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
         },
       },
       Object {
@@ -1649,36 +1559,6 @@ Array [
           "xhtml": false,
         },
       },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
-        },
-      },
       Object {},
       Object {
         "definitions": Object {
@@ -2044,36 +1924,6 @@ Array [
           "template": ".tmp_test/test-app/src/targets/browser/index.ejs",
           "title": "test-app",
           "xhtml": false,
-        },
-      },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
         },
       },
       Object {
@@ -2462,36 +2312,6 @@ Array [
           "template": ".tmp_test/test-app/src/targets/browser/index.ejs",
           "title": "test-app",
           "xhtml": false,
-        },
-      },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
         },
       },
       Object {
@@ -2945,36 +2765,6 @@ Array [
           "template": ".tmp_test/test-app/src/targets/browser/index.ejs",
           "title": "test-app",
           "xhtml": false,
-        },
-      },
-      Object {
-        "options": Object {
-          "async": Object {
-            "test": Array [],
-          },
-          "custom": Array [],
-          "defaultAttribute": "defer",
-          "defer": Object {
-            "test": Array [],
-          },
-          "inline": Object {
-            "test": Array [],
-          },
-          "module": Object {
-            "test": Array [],
-          },
-          "prefetch": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "preload": Object {
-            "chunks": "initial",
-            "test": Array [],
-          },
-          "removeInlinedAssets": true,
-          "sync": Object {
-            "test": Array [],
-          },
         },
       },
       Object {

--- a/packages/cozy-scripts/yarn.lock
+++ b/packages/cozy-scripts/yarn.lock
@@ -7601,13 +7601,6 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-script-ext-html-webpack-plugin@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-2.1.3.tgz#b4bf703cddbe3de2e6f483e19dfeba2b5ec4abfe"
-  integrity sha512-a/gqxJFw2IAs8LK/ZFBKv1YoeFysbntdiLBVdNfgHgMKWW1mMcRGY6Hm3aihSaY9tqqhcaXuQJ4nn19loNbkuQ==
-  dependencies:
-    debug "^4.1.0"
-
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"


### PR DESCRIPTION
The defer attribute for the scripts is not a good idea in the cozy context. We have small HTMLs, so we don't really benefit from it, and it can make the browsers execute the scripts before the CSS has been
loaded (flash of unstyled content).