### PR TITLE
feat: Make the minification faster

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.prod.js
+++ b/packages/cozy-scripts/config/webpack.environment.prod.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const webpack = require('webpack')
+const TerserPlugin = require('terser-webpack-plugin')
 
 const { target } = require('./webpack.vars')
 
@@ -14,5 +15,12 @@ module.exports = {
       __DEVTOOLS__: false,
       __STACK_ASSETS__: target !== 'mobile'
     })
-  ]
+  ],
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        parallel: true
+      })
+    ]
+  }
 }

--- a/packages/cozy-scripts/docs/webpack-configs.md
+++ b/packages/cozy-scripts/docs/webpack-configs.md
@@ -368,7 +368,7 @@ Only in the hot reload mode:
     - `__DEVTOOLS__` to `false`
     - `__STACK_ASSETS__` to `true` if `target` different from `mobile`
 
-In this production mode, webpack will automatically use the `UglifyJs` plugin to optimize the build (with default options).
+In this production mode, webpack will automatically use the `Terser` plugin to optimize the build (with `parallel: true` to speedup the build).
 
 
 ## Targets

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -586,6 +586,22 @@ Array [
       ],
     },
     "optimization": Object {
+      "minimizer": Array [
+        Object {
+          "options": Object {
+            "cache": false,
+            "extractComments": false,
+            "parallel": true,
+            "sourceMap": false,
+            "terserOptions": Object {
+              "output": Object {
+                "comments": Object {},
+              },
+            },
+            "test": Object {},
+          },
+        },
+      ],
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
@@ -1388,6 +1404,22 @@ Array [
       ],
     },
     "optimization": Object {
+      "minimizer": Array [
+        Object {
+          "options": Object {
+            "cache": false,
+            "extractComments": false,
+            "parallel": true,
+            "sourceMap": false,
+            "terserOptions": Object {
+              "output": Object {
+                "comments": Object {},
+              },
+            },
+            "test": Object {},
+          },
+        },
+      ],
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -668,6 +668,22 @@ Array [
       ],
     },
     "optimization": Object {
+      "minimizer": Array [
+        Object {
+          "options": Object {
+            "cache": false,
+            "extractComments": false,
+            "parallel": true,
+            "sourceMap": false,
+            "terserOptions": Object {
+              "output": Object {
+                "comments": Object {},
+              },
+            },
+            "test": Object {},
+          },
+        },
+      ],
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {
@@ -1502,6 +1518,22 @@ Array [
       ],
     },
     "optimization": Object {
+      "minimizer": Array [
+        Object {
+          "options": Object {
+            "cache": false,
+            "extractComments": false,
+            "parallel": true,
+            "sourceMap": false,
+            "terserOptions": Object {
+              "output": Object {
+                "comments": Object {},
+              },
+            },
+            "test": Object {},
+          },
+        },
+      ],
       "splitChunks": Object {
         "cacheGroups": Object {
           "vendors": Object {


### PR DESCRIPTION
Terser is used by default with recent version of webpack (instead of UglifyJS), and its documentation recommends to enable the parallel option to make the build faster:

> Parallelization can speedup your build significantly and is therefore highly recommended.

https://github.com/webpack-contrib/terser-webpack-plugin#parallel