### PR TITLE
chore: Use the favicon from the stack

### DIFF
--- a/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
+++ b/packages/cozy-scripts/template/app/src/targets/browser/index.ejs
@@ -8,6 +8,7 @@
       <link rel="stylesheet" href="<%- file %>">
   <% }); %>
   {{.ThemeCSS}}
+  {{.Favicon}}
   <% if (__TARGET__ === 'mobile') { %>
   <meta name="format-detection" content="telephone=no">
   <script src="cordova.js" defer></script>


### PR DESCRIPTION
The favicon from the stack can be customized for B2B via the dynamic
assets, and it should be used for the core apps.

[Ref](https://github.com/cozy/cozy-banks/pull/920/commits/3098e9cb713551d327d1dbdac4b5aa2296dc80cd)