### PR TITLE
fix(travis): Branches directive 🚑

### DIFF
--- a/packages/cozy-scripts/template-vue/.travis.yml
+++ b/packages/cozy-scripts/template-vue/.travis.yml
@@ -6,6 +6,8 @@ node_js:
 branches:
   only:
   - master
+  # tags
+  - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
   # GITHUB_TOKEN for yarn deploy script

--- a/packages/cozy-scripts/template/.travis.yml
+++ b/packages/cozy-scripts/template/.travis.yml
@@ -6,6 +6,8 @@ node_js:
 branches:
   only:
   - master
+  # tags
+  - /^\d+\.\d+\.\d+(\-beta.\d+)?$/
 env:
   global:
   # GITHUB_TOKEN for yarn deploy script


### PR DESCRIPTION
Using the `only` directive prevent tags from being built.
See https://docs.travis-ci.com/user/customizing-the-build#safelisting-or-blocklisting-branches
(regexp test https://regex101.com/r/wsBW0t/1/)

[see @gregorylegarec commit](https://github.com/cozy/cozy-store/pull/551)