### PR TITLE
feat: Don't use the slow stylus resolver

### DIFF
--- a/packages/cozy-scripts/config/webpack.config.cozy-ui.js
+++ b/packages/cozy-scripts/config/webpack.config.cozy-ui.js
@@ -37,6 +37,7 @@ module.exports = {
           {
             loader: require.resolve('stylus-loader'),
             options: {
+              preferPathResolver: 'webpack',
               use: [cozyUIPlugin()]
             }
           }

--- a/packages/cozy-scripts/config/webpack.config.css-modules.js
+++ b/packages/cozy-scripts/config/webpack.config.css-modules.js
@@ -37,7 +37,12 @@ module.exports = {
               }
             }
           },
-          require.resolve('stylus-loader')
+          {
+            loader: require.resolve('stylus-loader'),
+            options: {
+              preferPathResolver: 'webpack'
+            }
+          }
         ]
       }
     ]

--- a/packages/cozy-scripts/docs/webpack-merge-strategies.md
+++ b/packages/cozy-scripts/docs/webpack-merge-strategies.md
@@ -65,7 +65,12 @@ module.exports = [configs,
                   }
                 }
               },
-              'stylus-loader'
+              {
+                loader: 'stylus-loader',
+                options: {
+                  preferPathResolver: 'webpack'
+                }
+              }
             ]
           })
         }

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -129,6 +129,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -543,6 +544,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -943,6 +945,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -1361,6 +1364,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -1768,6 +1772,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -2183,6 +2188,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app-vue/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -45,7 +45,12 @@ Array [
                 "sourceMap": true,
               },
             },
-            "stylus-loader",
+            Object {
+              "loader": "stylus-loader",
+              "options": Object {
+                "preferPathResolver": "webpack",
+              },
+            },
           ],
         },
       ],
@@ -195,6 +200,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -625,6 +631,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -1041,6 +1048,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -1475,6 +1483,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -1898,6 +1907,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -2329,6 +2339,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],
@@ -2825,6 +2836,7 @@ Array [
             Object {
               "loader": ".tmp_test/test-app/node_modules/cozy-scripts/node_modules/stylus-loader/index.js",
               "options": Object {
+                "preferPathResolver": "webpack",
                 "use": Array [
                   null,
                 ],

--- a/packages/cozy-scripts/test/lib/strategy.config.js
+++ b/packages/cozy-scripts/test/lib/strategy.config.js
@@ -55,7 +55,12 @@ const configs = [
                 }
               }
             },
-            'stylus-loader'
+            {
+              loader: 'stylus-loader',
+              options: {
+                preferPathResolver: 'webpack'
+              }
+            }
           ]
         }
       ]
@@ -95,7 +100,12 @@ const configs = [
                 }
               }
             },
-            'stylus-loader'
+            {
+              loader: 'stylus-loader',
+              options: {
+                preferPathResolver: 'webpack'
+              }
+            }
           ]
         }
       ]


### PR DESCRIPTION
Stylus has its own resolver, but it is slower and it doesn't work when importing a file from another package. It still works because stylus-loader has a fallback on webpack resolver in those cases. But it's faster and, I think, saner to use directly webpack resolver.

See https://github.com/shama/stylus-loader#prefer-webpack-resolving

For example, I've tried on cozy-settings, and yarn build takes 39s before this change, and only 31s after. I also think we win around 8s for yarn watch but it's harder to measure.