### PR TITLE
chore: Fix yarn test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 		"postinstall": "lerna bootstrap",
 		"changelog": "lerna-changelog",
 		"lint": "eslint --ignore-path .gitignore './**/*.{js,jsx}'",
-		"test": "yarn test:cli && yarn test:cozy-scripts && yarn test:cozy-scripts-vanilla",
+		"test": "yarn test:cca && yarn test:cozy-scripts && yarn test:cozy-scripts-vanilla",
 		"test:tools": "yarn test:cca && yarn test:cozy-scripts:cli --coverage && yarn test:cozy-scripts:utils --coverage",
 		"test:cca": "bash packages/create-cozy-app/test/create-cozy-app.sh",
 		"test:cozy-scripts": "yarn test:cozy-scripts:cli && yarn test:cozy-scripts:default && yarn test:cozy-scripts:vue",


### PR DESCRIPTION
The test:cli rule has been renamed to test:tools in the past. But as test:tools has some overlaps with the test rule, I've fixed it but making the test rule doing something similar to what is on travis.