### PR TITLE
fix: Support window in HMR env

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.dev.js
+++ b/packages/cozy-scripts/config/webpack.environment.dev.js
@@ -51,13 +51,16 @@ let plugins = [
   })
 ]
 
+let output = {}
 if (useHotReload) {
   plugins = plugins.concat([new webpack.HotModuleReplacementPlugin()])
+  output.globalObject = 'this'
 }
 
 module.exports = {
   devtool: '#source-map',
   mode: 'development',
   externals: ['cozy'],
-  plugins
+  plugins,
+  output
 }


### PR DESCRIPTION
Since we're using HMR on Drive, we had an error : window is not defined. 

See: https://github.com/webpack/webpack/issues/6642#issuecomment-370222543