### PR TITLE
fix: Safari 10 issue

### DIFF
--- a/packages/cozy-scripts/config/webpack.environment.prod.js
+++ b/packages/cozy-scripts/config/webpack.environment.prod.js
@@ -19,7 +19,11 @@ module.exports = {
   optimization: {
     minimizer: [
       new TerserPlugin({
-        parallel: true
+        parallel: true,
+        //To fix a SAfari 10 bug : https://github.com/zeit/next.js/issues/5630
+        terserOptions: {
+          safari10: true
+        }
       })
     ]
   }

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -576,6 +576,7 @@ Array [
               "output": Object {
                 "comments": Object {},
               },
+              "safari10": true,
             },
             "test": Object {},
           },
@@ -1350,6 +1351,7 @@ Array [
               "output": Object {
                 "comments": Object {},
               },
+              "safari10": true,
             },
             "test": Object {},
           },

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -663,6 +663,7 @@ Array [
               "output": Object {
                 "comments": Object {},
               },
+              "safari10": true,
             },
             "test": Object {},
           },
@@ -1469,6 +1470,7 @@ Array [
               "output": Object {
                 "comments": Object {},
               },
+              "safari10": true,
             },
             "test": Object {},
           },


### PR DESCRIPTION
Resolve the "can't declare twice a const". This is a Safari 10 bug... 

See https://github.com/zeit/next.js/issues/5630 & https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/92