### PR TITLE
Add speead measure webpack plugin on debug mode

### DIFF
--- a/packages/cozy-scripts/package.json
+++ b/packages/cozy-scripts/package.json
@@ -49,6 +49,7 @@
     "prompt": "1.0.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
+    "speed-measure-webpack-plugin": "1.3.1",
     "style-loader": "0.23.1",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.2",

--- a/packages/cozy-scripts/scripts/config.js
+++ b/packages/cozy-scripts/scripts/config.js
@@ -1,9 +1,12 @@
 'use strict'
 
 const merge = require('webpack-merge')
+const SpeedMeasurePlugin = require('speed-measure-webpack-plugin')
 const path = require('path')
 const fs = require('fs-extra')
 const CTS = require('../utils/constants.js')
+
+const smp = new SpeedMeasurePlugin()
 
 function mergeWithOptions(options, configs, current) {
   // merge with the previous configs using the provided strategy
@@ -24,6 +27,7 @@ function getWebpackConfigs(options = {}) {
 
   // NODE_ENV from environment overwrite options here
   if (!process.env.NODE_ENV) process.env.NODE_ENV = `${target}:${mode}`
+  const isDebugMode = process.env[CTS.DEBUG] === 'true'
 
   // check if a custom config exists in the app source
   let appConfigs
@@ -75,13 +79,13 @@ function getWebpackConfigs(options = {}) {
         separateConfig = merge(mergedConfig, configPart)
       }
       if (separateConfig.multiple) delete separateConfig.multiple
-      configs.push(separateConfig)
+      configs.push(isDebugMode ? smp.wrap(separateConfig) : separateConfig)
     }
     delete mergedConfig.multiple
   }
 
   // replace the first position placeholder in the list
-  configs[0] = mergedConfig
+  configs[0] = isDebugMode ? smp.wrap(mergedConfig) : mergedConfig
 
   return merge.multiple(configs)
 }

--- a/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts-vue.spec.js.snap
@@ -2324,6 +2324,11 @@ Array [
           "publicPath": true,
         },
       },
+      Object {
+        "options": Object {},
+        "smpPluginAdded": true,
+        "timeEventData": Object {},
+      },
     ],
     "resolve": Object {
       "extensions": Array [

--- a/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
+++ b/packages/cozy-scripts/test/__snapshots__/scripts.spec.js.snap
@@ -2461,6 +2461,11 @@ Array [
           "publicPath": true,
         },
       },
+      Object {
+        "options": Object {},
+        "smpPluginAdded": true,
+        "timeEventData": Object {},
+      },
     ],
     "resolve": Object {
       "alias": Object {

--- a/packages/cozy-scripts/yarn.lock
+++ b/packages/cozy-scripts/yarn.lock
@@ -6694,6 +6694,13 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+speed-measure-webpack-plugin@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.1.tgz#69840a5cdc08b4638697dac7db037f595d7f36a0"
+  integrity sha512-qVIkJvbtS9j/UeZumbdfz0vg+QfG/zxonAjzefZrqzkr7xOncLVXkeGbTpzd1gjCBM4PmVNkWlkeTVhgskAGSQ==
+  dependencies:
+    chalk "^2.0.1"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"


### PR DESCRIPTION
Using `--debug` we will now get more timing information during webpack scripts
<img width="455" alt="Screenshot 2019-07-03 at 15 47 58" src="https://user-images.githubusercontent.com/10224453/60791463-01c4ff80-a164-11e9-8d3d-fd50db350bfc.png">